### PR TITLE
Remove need for payer to sign to validate

### DIFF
--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "name": "mpl_token_auth_rules",
   "instructions": [
     {
@@ -542,6 +542,16 @@
       "code": 19,
       "name": "MissingPayloadValue",
       "msg": "Missing Payload value"
+    },
+    {
+      "code": 20,
+      "name": "RuleSetOwnerMismatch",
+      "msg": "RuleSet owner must be payer"
+    },
+    {
+      "code": 21,
+      "name": "NameTooLong",
+      "msg": "Name too long"
     }
   ],
   "metadata": {

--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -41,10 +41,10 @@
       "name": "Validate",
       "accounts": [
         {
-          "name": "payer",
+          "name": "owner",
           "isMut": true,
-          "isSigner": true,
-          "desc": "Payer and creator of the RuleSet"
+          "isSigner": false,
+          "desc": "Owner (creator) of the RuleSet"
         },
         {
           "name": "ruleSet",
@@ -495,12 +495,17 @@
     {
       "code": 14,
       "name": "BorshSerializationError",
-      "msg": "Borsh Serialization Error"
+      "msg": "Borsh serialization error"
     },
     {
       "code": 15,
       "name": "PayloadValueOccupied",
       "msg": "Value in Payload is occupied"
+    },
+    {
+      "code": 16,
+      "name": "DataIsEmpty",
+      "msg": "Account data is empty"
     }
   ],
   "metadata": {

--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -22,6 +22,41 @@
           "isMut": false,
           "isSigner": false,
           "desc": "System program"
+        },
+        {
+          "name": "optRulePda1",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Optional rule PDA non-signer 1",
+          "optional": true
+        },
+        {
+          "name": "optRulePda2",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Optional rule PDA non-signer 2",
+          "optional": true
+        },
+        {
+          "name": "optRulePda3",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Optional rule PDA non-signer 3",
+          "optional": true
+        },
+        {
+          "name": "optRulePda4",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Optional rule PDA non-signer 4",
+          "optional": true
+        },
+        {
+          "name": "optRulePda5",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Optional rule PDA non-signer 5",
+          "optional": true
         }
       ],
       "args": [
@@ -40,12 +75,6 @@
     {
       "name": "Validate",
       "accounts": [
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": false,
-          "desc": "Owner (creator) of the RuleSet"
-        },
         {
           "name": "ruleSet",
           "isMut": true,
@@ -209,10 +238,6 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "ruleSetName",
-            "type": "string"
-          },
-          {
             "name": "serializedRuleSet",
             "type": "bytes"
           }
@@ -224,10 +249,6 @@
       "type": {
         "kind": "struct",
         "fields": [
-          {
-            "name": "ruleSetName",
-            "type": "string"
-          },
           {
             "name": "operation",
             "type": {
@@ -499,13 +520,28 @@
     },
     {
       "code": 15,
-      "name": "PayloadValueOccupied",
-      "msg": "Value in Payload is occupied"
+      "name": "ValueOccupied",
+      "msg": "Value in Payload or RuleSet is occupied"
     },
     {
       "code": 16,
       "name": "DataIsEmpty",
       "msg": "Account data is empty"
+    },
+    {
+      "code": 17,
+      "name": "MessagePackDeserializationError",
+      "msg": "MessagePack deserialization error"
+    },
+    {
+      "code": 18,
+      "name": "MissingAccount",
+      "msg": "Missing account"
+    },
+    {
+      "code": 19,
+      "name": "MissingPayloadValue",
+      "msg": "Missing Payload value"
     }
   ],
   "metadata": {

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -301,7 +301,7 @@ createErrorFromCodeLookup.set(0xd, () => new NotImplementedError());
 createErrorFromNameLookup.set('NotImplemented', () => new NotImplementedError());
 
 /**
- * BorshSerializationError: 'Borsh Serialization Error'
+ * BorshSerializationError: 'Borsh serialization error'
  *
  * @category Errors
  * @category generated
@@ -310,7 +310,7 @@ export class BorshSerializationErrorError extends Error {
   readonly code: number = 0xe;
   readonly name: string = 'BorshSerializationError';
   constructor() {
-    super('Borsh Serialization Error');
+    super('Borsh serialization error');
     if (typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, BorshSerializationErrorError);
     }
@@ -339,6 +339,26 @@ export class PayloadValueOccupiedError extends Error {
 
 createErrorFromCodeLookup.set(0xf, () => new PayloadValueOccupiedError());
 createErrorFromNameLookup.set('PayloadValueOccupied', () => new PayloadValueOccupiedError());
+
+/**
+ * DataIsEmpty: 'Account data is empty'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class DataIsEmptyError extends Error {
+  readonly code: number = 0x10;
+  readonly name: string = 'DataIsEmpty';
+  constructor() {
+    super('Account data is empty');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, DataIsEmptyError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x10, () => new DataIsEmptyError());
+createErrorFromNameLookup.set('DataIsEmpty', () => new DataIsEmptyError());
 
 /**
  * Attempts to resolve a custom program error from the provided error code.

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -424,6 +424,46 @@ createErrorFromCodeLookup.set(0x13, () => new MissingPayloadValueError());
 createErrorFromNameLookup.set('MissingPayloadValue', () => new MissingPayloadValueError());
 
 /**
+ * RuleSetOwnerMismatch: 'RuleSet owner must be payer'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class RuleSetOwnerMismatchError extends Error {
+  readonly code: number = 0x14;
+  readonly name: string = 'RuleSetOwnerMismatch';
+  constructor() {
+    super('RuleSet owner must be payer');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, RuleSetOwnerMismatchError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x14, () => new RuleSetOwnerMismatchError());
+createErrorFromNameLookup.set('RuleSetOwnerMismatch', () => new RuleSetOwnerMismatchError());
+
+/**
+ * NameTooLong: 'Name too long'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class NameTooLongError extends Error {
+  readonly code: number = 0x15;
+  readonly name: string = 'NameTooLong';
+  constructor() {
+    super('Name too long');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, NameTooLongError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x15, () => new NameTooLongError());
+createErrorFromNameLookup.set('NameTooLong', () => new NameTooLongError());
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -321,24 +321,24 @@ createErrorFromCodeLookup.set(0xe, () => new BorshSerializationErrorError());
 createErrorFromNameLookup.set('BorshSerializationError', () => new BorshSerializationErrorError());
 
 /**
- * PayloadValueOccupied: 'Value in Payload is occupied'
+ * ValueOccupied: 'Value in Payload or RuleSet is occupied'
  *
  * @category Errors
  * @category generated
  */
-export class PayloadValueOccupiedError extends Error {
+export class ValueOccupiedError extends Error {
   readonly code: number = 0xf;
-  readonly name: string = 'PayloadValueOccupied';
+  readonly name: string = 'ValueOccupied';
   constructor() {
-    super('Value in Payload is occupied');
+    super('Value in Payload or RuleSet is occupied');
     if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, PayloadValueOccupiedError);
+      Error.captureStackTrace(this, ValueOccupiedError);
     }
   }
 }
 
-createErrorFromCodeLookup.set(0xf, () => new PayloadValueOccupiedError());
-createErrorFromNameLookup.set('PayloadValueOccupied', () => new PayloadValueOccupiedError());
+createErrorFromCodeLookup.set(0xf, () => new ValueOccupiedError());
+createErrorFromNameLookup.set('ValueOccupied', () => new ValueOccupiedError());
 
 /**
  * DataIsEmpty: 'Account data is empty'
@@ -359,6 +359,69 @@ export class DataIsEmptyError extends Error {
 
 createErrorFromCodeLookup.set(0x10, () => new DataIsEmptyError());
 createErrorFromNameLookup.set('DataIsEmpty', () => new DataIsEmptyError());
+
+/**
+ * MessagePackDeserializationError: 'MessagePack deserialization error'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class MessagePackDeserializationErrorError extends Error {
+  readonly code: number = 0x11;
+  readonly name: string = 'MessagePackDeserializationError';
+  constructor() {
+    super('MessagePack deserialization error');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, MessagePackDeserializationErrorError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x11, () => new MessagePackDeserializationErrorError());
+createErrorFromNameLookup.set(
+  'MessagePackDeserializationError',
+  () => new MessagePackDeserializationErrorError(),
+);
+
+/**
+ * MissingAccount: 'Missing account'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class MissingAccountError extends Error {
+  readonly code: number = 0x12;
+  readonly name: string = 'MissingAccount';
+  constructor() {
+    super('Missing account');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, MissingAccountError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x12, () => new MissingAccountError());
+createErrorFromNameLookup.set('MissingAccount', () => new MissingAccountError());
+
+/**
+ * MissingPayloadValue: 'Missing Payload value'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class MissingPayloadValueError extends Error {
+  readonly code: number = 0x13;
+  readonly name: string = 'MissingPayloadValue';
+  constructor() {
+    super('Missing Payload value');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, MissingPayloadValueError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x13, () => new MissingPayloadValueError());
+createErrorFromNameLookup.set('MissingPayloadValue', () => new MissingPayloadValueError());
 
 /**
  * Attempts to resolve a custom program error from the provided error code.

--- a/packages/sdk/src/generated/instructions/Create.ts
+++ b/packages/sdk/src/generated/instructions/Create.ts
@@ -38,6 +38,11 @@ export const CreateStruct = new beet.FixableBeetArgsStruct<
  *
  * @property [_writable_, **signer**] payer Payer and creator of the RuleSet
  * @property [_writable_] ruleSetPda The PDA account where the RuleSet is stored
+ * @property [] optRulePda1 (optional) Optional rule PDA non-signer 1
+ * @property [] optRulePda2 (optional) Optional rule PDA non-signer 2
+ * @property [] optRulePda3 (optional) Optional rule PDA non-signer 3
+ * @property [] optRulePda4 (optional) Optional rule PDA non-signer 4
+ * @property [] optRulePda5 (optional) Optional rule PDA non-signer 5
  * @category Instructions
  * @category Create
  * @category generated
@@ -46,12 +51,22 @@ export type CreateInstructionAccounts = {
   payer: web3.PublicKey;
   ruleSetPda: web3.PublicKey;
   systemProgram?: web3.PublicKey;
+  optRulePda1?: web3.PublicKey;
+  optRulePda2?: web3.PublicKey;
+  optRulePda3?: web3.PublicKey;
+  optRulePda4?: web3.PublicKey;
+  optRulePda5?: web3.PublicKey;
 };
 
 export const createInstructionDiscriminator = 0;
 
 /**
  * Creates a _Create_ instruction.
+ *
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
  *
  * @param accounts that will be accessed while the instruction is processed
  * @param args to provide as instruction data to the program
@@ -86,6 +101,71 @@ export function createCreateInstruction(
       isSigner: false,
     },
   ];
+
+  if (accounts.optRulePda1 != null) {
+    keys.push({
+      pubkey: accounts.optRulePda1,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
+  if (accounts.optRulePda2 != null) {
+    if (accounts.optRulePda1 == null) {
+      throw new Error(
+        "When providing 'optRulePda2' then 'accounts.optRulePda1' need(s) to be provided as well.",
+      );
+    }
+    keys.push({
+      pubkey: accounts.optRulePda2,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
+  if (accounts.optRulePda3 != null) {
+    if (accounts.optRulePda1 == null || accounts.optRulePda2 == null) {
+      throw new Error(
+        "When providing 'optRulePda3' then 'accounts.optRulePda1', 'accounts.optRulePda2' need(s) to be provided as well.",
+      );
+    }
+    keys.push({
+      pubkey: accounts.optRulePda3,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
+  if (accounts.optRulePda4 != null) {
+    if (
+      accounts.optRulePda1 == null ||
+      accounts.optRulePda2 == null ||
+      accounts.optRulePda3 == null
+    ) {
+      throw new Error(
+        "When providing 'optRulePda4' then 'accounts.optRulePda1', 'accounts.optRulePda2', 'accounts.optRulePda3' need(s) to be provided as well.",
+      );
+    }
+    keys.push({
+      pubkey: accounts.optRulePda4,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
+  if (accounts.optRulePda5 != null) {
+    if (
+      accounts.optRulePda1 == null ||
+      accounts.optRulePda2 == null ||
+      accounts.optRulePda3 == null ||
+      accounts.optRulePda4 == null
+    ) {
+      throw new Error(
+        "When providing 'optRulePda5' then 'accounts.optRulePda1', 'accounts.optRulePda2', 'accounts.optRulePda3', 'accounts.optRulePda4' need(s) to be provided as well.",
+      );
+    }
+    keys.push({
+      pubkey: accounts.optRulePda5,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
 
   const ix = new web3.TransactionInstruction({
     programId,

--- a/packages/sdk/src/generated/instructions/Validate.ts
+++ b/packages/sdk/src/generated/instructions/Validate.ts
@@ -36,7 +36,7 @@ export const ValidateStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _Validate_ instruction
  *
- * @property [_writable_, **signer**] payer Payer and creator of the RuleSet
+ * @property [_writable_] owner Owner (creator) of the RuleSet
  * @property [_writable_] ruleSet The PDA account where the RuleSet is stored
  * @property [**signer**] optRuleSigner1 (optional) Optional rule validation signer 1
  * @property [**signer**] optRuleSigner2 (optional) Optional rule validation signer 2
@@ -53,7 +53,7 @@ export const ValidateStruct = new beet.FixableBeetArgsStruct<
  * @category generated
  */
 export type ValidateInstructionAccounts = {
-  payer: web3.PublicKey;
+  owner: web3.PublicKey;
   ruleSet: web3.PublicKey;
   systemProgram?: web3.PublicKey;
   optRuleSigner1?: web3.PublicKey;
@@ -96,9 +96,9 @@ export function createValidateInstruction(
   });
   const keys: web3.AccountMeta[] = [
     {
-      pubkey: accounts.payer,
+      pubkey: accounts.owner,
       isWritable: true,
-      isSigner: true,
+      isSigner: false,
     },
     {
       pubkey: accounts.ruleSet,

--- a/packages/sdk/src/generated/instructions/Validate.ts
+++ b/packages/sdk/src/generated/instructions/Validate.ts
@@ -36,7 +36,6 @@ export const ValidateStruct = new beet.FixableBeetArgsStruct<
 /**
  * Accounts required by the _Validate_ instruction
  *
- * @property [_writable_] owner Owner (creator) of the RuleSet
  * @property [_writable_] ruleSet The PDA account where the RuleSet is stored
  * @property [**signer**] optRuleSigner1 (optional) Optional rule validation signer 1
  * @property [**signer**] optRuleSigner2 (optional) Optional rule validation signer 2
@@ -53,7 +52,6 @@ export const ValidateStruct = new beet.FixableBeetArgsStruct<
  * @category generated
  */
 export type ValidateInstructionAccounts = {
-  owner: web3.PublicKey;
   ruleSet: web3.PublicKey;
   systemProgram?: web3.PublicKey;
   optRuleSigner1?: web3.PublicKey;
@@ -95,11 +93,6 @@ export function createValidateInstruction(
     ...args,
   });
   const keys: web3.AccountMeta[] = [
-    {
-      pubkey: accounts.owner,
-      isWritable: true,
-      isSigner: false,
-    },
     {
       pubkey: accounts.ruleSet,
       isWritable: true,

--- a/packages/sdk/src/generated/types/CreateArgs.ts
+++ b/packages/sdk/src/generated/types/CreateArgs.ts
@@ -7,7 +7,6 @@
 
 import * as beet from '@metaplex-foundation/beet';
 export type CreateArgs = {
-  ruleSetName: string;
   serializedRuleSet: Uint8Array;
 };
 
@@ -16,9 +15,6 @@ export type CreateArgs = {
  * @category generated
  */
 export const createArgsBeet = new beet.FixableBeetArgsStruct<CreateArgs>(
-  [
-    ['ruleSetName', beet.utf8String],
-    ['serializedRuleSet', beet.bytes],
-  ],
+  [['serializedRuleSet', beet.bytes]],
   'CreateArgs',
 );

--- a/packages/sdk/src/generated/types/ValidateArgs.ts
+++ b/packages/sdk/src/generated/types/ValidateArgs.ts
@@ -9,7 +9,6 @@ import * as beet from '@metaplex-foundation/beet';
 import { Operation, operationBeet } from './Operation';
 import { Payload, payloadBeet } from './Payload';
 export type ValidateArgs = {
-  ruleSetName: string;
   operation: Operation;
   payload: Payload;
 };
@@ -20,7 +19,6 @@ export type ValidateArgs = {
  */
 export const validateArgsBeet = new beet.FixableBeetArgsStruct<ValidateArgs>(
   [
-    ['ruleSetName', beet.utf8String],
     ['operation', operationBeet],
     ['payload', payloadBeet],
   ],

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -64,13 +64,17 @@ pub enum RuleSetError {
     #[error("Not implemented")]
     NotImplemented,
 
-    /// 14 - Borsh Serialization Error
-    #[error("Borsh Serialization Error")]
+    /// 14 - Borsh serialization error
+    #[error("Borsh serialization error")]
     BorshSerializationError,
 
     /// 15 - Value in Payload is occupied
     #[error("Value in Payload is occupied")]
     PayloadValueOccupied,
+
+    /// 16 - Account data is empty
+    #[error("Account data is empty")]
+    DataIsEmpty,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -68,13 +68,17 @@ pub enum RuleSetError {
     #[error("Borsh serialization error")]
     BorshSerializationError,
 
-    /// 15 - Value in Payload is occupied
-    #[error("Value in Payload is occupied")]
-    PayloadValueOccupied,
+    /// 15 - Value in Payload or RuleSet is occupied
+    #[error("Value in Payload or RuleSet is occupied")]
+    ValueOccupied,
 
     /// 16 - Account data is empty
     #[error("Account data is empty")]
     DataIsEmpty,
+
+    /// 17 - MessagePack deserialization error
+    #[error("MessagePack deserialization error")]
+    MessagePackDeserializationError,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -87,6 +87,14 @@ pub enum RuleSetError {
     /// 19 - Missing Payload value
     #[error("Missing Payload value")]
     MissingPayloadValue,
+
+    /// 20 - RuleSet owner must be payer
+    #[error("RuleSet owner must be payer")]
+    RuleSetOwnerMismatch,
+
+    /// 21 - Name too long
+    #[error("Name too long")]
+    NameTooLong,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -79,6 +79,14 @@ pub enum RuleSetError {
     /// 17 - MessagePack deserialization error
     #[error("MessagePack deserialization error")]
     MessagePackDeserializationError,
+
+    /// 18 - Missing account
+    #[error("Missing account")]
+    MissingAccount,
+
+    /// 19 - Missing Payload value
+    #[error("Missing Payload value")]
+    MissingPayloadValue,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -46,6 +46,11 @@ pub enum RuleSetInstruction {
     #[account(0, writable, signer, name="payer", desc="Payer and creator of the RuleSet")]
     #[account(1, writable, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
+    #[account(3, optional, name = "opt_rule_pda_1", desc = "Optional rule PDA non-signer 1")]
+    #[account(4, optional, name = "opt_rule_pda_2", desc = "Optional rule PDA non-signer 2")]
+    #[account(5, optional, name = "opt_rule_pda_3", desc = "Optional rule PDA non-signer 3")]
+    #[account(6, optional, name = "opt_rule_pda_4", desc = "Optional rule PDA non-signer 4")]
+    #[account(7, optional, name = "opt_rule_pda_5", desc = "Optional rule PDA non-signer 5")]
     Create(CreateArgs),
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by sending
@@ -76,12 +81,23 @@ pub fn create(
     payer: Pubkey,
     rule_set_pda: Pubkey,
     serialized_rule_set: Vec<u8>,
+    rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
-    let accounts = vec![
+    let mut accounts = vec![
         AccountMeta::new(payer, true),
         AccountMeta::new(rule_set_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
+
+    for i in 0..5 {
+        if let Some(account) = rule_nonsigner_accounts.get(i) {
+            accounts.push(AccountMeta::new_readonly(*account, false));
+        }
+    }
+
+    if rule_nonsigner_accounts.get(5).is_some() {
+        panic!("Too many rule PDA non-signer accounts");
+    }
 
     Instruction {
         program_id,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -54,7 +54,7 @@ pub enum RuleSetInstruction {
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by sending
     /// it an `AccountsMap` and a `PayloadMap` and calling the `RuleSet`'s `validate` method.
-    #[account(0, writable, signer, name="payer", desc="Payer and creator of the RuleSet")]
+    #[account(0, writable, name="owner", desc="Owner (creator) of the RuleSet")]
     #[account(1, writable, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
     #[account(3, optional, signer, name="opt_rule_signer_1", desc = "Optional rule validation signer 1")]
@@ -105,7 +105,7 @@ pub fn create(
 #[allow(clippy::too_many_arguments)]
 pub fn validate(
     program_id: Pubkey,
-    payer: Pubkey,
+    owner: Pubkey,
     rule_set_pda: Pubkey,
     rule_set_name: String,
     operation: Operation,
@@ -114,7 +114,7 @@ pub fn validate(
     rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(payer, true),
+        AccountMeta::new(owner, false),
         AccountMeta::new(rule_set_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -10,8 +10,6 @@ use solana_program::{
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Args for `create` instruction.
 pub struct CreateArgs {
-    /// Name of the RuleSet, used in PDA derivation.
-    pub rule_set_name: String,
     /// RuleSet pre-serialized by caller into the MessagePack format.
     pub serialized_rule_set: Vec<u8>,
 }
@@ -20,8 +18,6 @@ pub struct CreateArgs {
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Args for `validate` instruction.
 pub struct ValidateArgs {
-    /// Name of the RuleSet, used in PDA derivation.
-    pub rule_set_name: String,
     /// `Operation` to validate.
     pub operation: Operation,
     /// `Payload` data used for rule validation.
@@ -54,19 +50,18 @@ pub enum RuleSetInstruction {
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by sending
     /// it an `AccountsMap` and a `PayloadMap` and calling the `RuleSet`'s `validate` method.
-    #[account(0, writable, name="owner", desc="Owner (creator) of the RuleSet")]
-    #[account(1, writable, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
-    #[account(2, name = "system_program", desc = "System program")]
-    #[account(3, optional, signer, name="opt_rule_signer_1", desc = "Optional rule validation signer 1")]
-    #[account(4, optional, signer, name="opt_rule_signer_2", desc = "Optional rule validation signer 2")]
-    #[account(5, optional, signer, name="opt_rule_signer_3", desc = "Optional rule validation signer 3")]
-    #[account(6, optional, signer, name="opt_rule_signer_4", desc = "Optional rule validation signer 4")]
-    #[account(7, optional, signer, name="opt_rule_signer_5", desc = "Optional rule validation signer 5")]
-    #[account(8, optional, name = "opt_rule_nonsigner_1", desc = "Optional rule validation non-signer 1")]
-    #[account(9, optional, name = "opt_rule_nonsigner_2", desc = "Optional rule validation non-signer 2")]
-    #[account(10, optional, name = "opt_rule_nonsigner_3", desc = "Optional rule validation non-signer 3")]
-    #[account(11, optional, name = "opt_rule_nonsigner_4", desc = "Optional rule validation non-signer 4")]
-    #[account(12, optional, name = "opt_rule_nonsigner_5", desc = "Optional rule validation non-signer 5")]
+    #[account(0, writable, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
+    #[account(1, name = "system_program", desc = "System program")]
+    #[account(2, optional, signer, name="opt_rule_signer_1", desc = "Optional rule validation signer 1")]
+    #[account(3, optional, signer, name="opt_rule_signer_2", desc = "Optional rule validation signer 2")]
+    #[account(4, optional, signer, name="opt_rule_signer_3", desc = "Optional rule validation signer 3")]
+    #[account(5, optional, signer, name="opt_rule_signer_4", desc = "Optional rule validation signer 4")]
+    #[account(6, optional, signer, name="opt_rule_signer_5", desc = "Optional rule validation signer 5")]
+    #[account(7, optional, name = "opt_rule_nonsigner_1", desc = "Optional rule validation non-signer 1")]
+    #[account(8, optional, name = "opt_rule_nonsigner_2", desc = "Optional rule validation non-signer 2")]
+    #[account(9, optional, name = "opt_rule_nonsigner_3", desc = "Optional rule validation non-signer 3")]
+    #[account(10, optional, name = "opt_rule_nonsigner_4", desc = "Optional rule validation non-signer 4")]
+    #[account(11, optional, name = "opt_rule_nonsigner_5", desc = "Optional rule validation non-signer 5")]
     Validate(ValidateArgs),
 
     /// This instruction stores a Frequency Rule into a Frequency Rule PDA account.
@@ -80,7 +75,6 @@ pub fn create(
     program_id: Pubkey,
     payer: Pubkey,
     rule_set_pda: Pubkey,
-    rule_set_name: String,
     serialized_rule_set: Vec<u8>,
 ) -> Instruction {
     let accounts = vec![
@@ -93,7 +87,6 @@ pub fn create(
         program_id,
         accounts,
         data: RuleSetInstruction::Create(CreateArgs {
-            rule_set_name,
             serialized_rule_set,
         })
         .try_to_vec()
@@ -105,16 +98,13 @@ pub fn create(
 #[allow(clippy::too_many_arguments)]
 pub fn validate(
     program_id: Pubkey,
-    owner: Pubkey,
     rule_set_pda: Pubkey,
-    rule_set_name: String,
     operation: Operation,
     payload: Payload,
     rule_signer_accounts: Vec<Pubkey>,
     rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(owner, false),
         AccountMeta::new(rule_set_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
@@ -142,13 +132,9 @@ pub fn validate(
     Instruction {
         program_id,
         accounts,
-        data: RuleSetInstruction::Validate(ValidateArgs {
-            rule_set_name,
-            operation,
-            payload,
-        })
-        .try_to_vec()
-        .unwrap(),
+        data: RuleSetInstruction::Validate(ValidateArgs { operation, payload })
+            .try_to_vec()
+            .unwrap(),
     }
 }
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -9,4 +9,7 @@ pub mod utils;
 
 pub use solana_program;
 
+/// Max name length for any of the names used in this crate.
+pub const MAX_NAME_LENGTH: usize = 32;
+
 solana_program::declare_id!("auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg");

--- a/program/src/payload.rs
+++ b/program/src/payload.rs
@@ -70,10 +70,11 @@ impl Payload {
     /// Tries to insert a key-value pair into a `Payload`.  If this key is already in the `Payload`
     /// nothing is updated and an error is returned.
     pub fn try_insert(&mut self, key: PayloadKey, value: PayloadType) -> ProgramResult {
-        if self.map.get(&key).is_none() && self.map.insert(key, value).is_none() {
+        if self.map.get(&key).is_none() {
+            self.map.insert(key, value);
             Ok(())
         } else {
-            Err(RuleSetError::PayloadValueOccupied.into())
+            Err(RuleSetError::ValueOccupied.into())
         }
     }
 

--- a/program/src/pda.rs
+++ b/program/src/pda.rs
@@ -10,7 +10,7 @@ pub fn find_rule_set_address(creator: Pubkey, rule_set_name: String) -> (Pubkey,
             creator.as_ref(),
             rule_set_name.as_bytes(),
         ],
-        &crate::id(),
+        &crate::ID,
     )
 }
 
@@ -26,6 +26,6 @@ pub fn find_frequency_pda_address(
             rule_set_name.as_bytes(),
             freq_rule_name.as_bytes(),
         ],
-        &crate::id(),
+        &crate::ID,
     )
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -88,7 +88,7 @@ impl Processor {
                 let _system_program_info = next_account_info(account_info_iter)?;
 
                 // RuleSet must be owned by this program.
-                if rule_set_pda_info.owner != program_id {
+                if *rule_set_pda_info.owner != crate::ID {
                     return Err(RuleSetError::IncorrectOwner.into());
                 }
 

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -79,7 +79,7 @@ where {
             .map_err(|_| RuleSetError::DataTypeMismatch)?;
 
         // Check that this account is owned by this program.
-        assert_owned_by(a, &crate::id())?;
+        assert_owned_by(a, &crate::ID)?;
 
         Ok(ua)
     }

--- a/program/src/state/rule_set.rs
+++ b/program/src/state/rule_set.rs
@@ -1,21 +1,50 @@
-use crate::state::{Operation, Rule};
+use crate::{
+    error::RuleSetError,
+    state::{Operation, Rule},
+};
 use serde::{Deserialize, Serialize};
+use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
 pub struct RuleSet {
+    /// Name of the RuleSet, used in PDA derivation.
+    rule_set_name: String,
+    /// Owner (creator) of the RuleSet.
+    owner: Pubkey,
+    /// A map to determine the `Rule` that belongs to a given `Operation`.
     pub operations: HashMap<Operation, Rule>,
 }
 
 impl RuleSet {
-    pub fn new() -> Self {
+    /// Create a new empty `RuleSet`.
+    pub fn new(rule_set_name: String, owner: Pubkey) -> Self {
         Self {
+            rule_set_name,
+            owner,
             operations: HashMap::new(),
         }
     }
 
-    pub fn add(&mut self, operation: Operation, rules: Rule) {
-        self.operations.insert(operation, rules);
+    /// Get the name of the `RuleSet`.
+    pub fn name(&self) -> &str {
+        &self.rule_set_name
+    }
+
+    /// Get the owner of the `RuleSet`.
+    pub fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+
+    /// Add a key-value pair into a `RuleSet`.  If this key is already in the `RuleSet`
+    /// nothing is updated and an error is returned.
+    pub fn add(&mut self, operation: Operation, rules: Rule) -> ProgramResult {
+        if self.operations.get(&operation).is_none() {
+            self.operations.insert(operation, rules);
+            Ok(())
+        } else {
+            Err(RuleSetError::ValueOccupied.into())
+        }
     }
 
     pub fn get(&self, operation: Operation) -> Option<&Rule> {

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -136,7 +136,7 @@ impl Rule {
                     .map(Vec::as_slice)
                     .collect::<Vec<&[u8]>>();
                 let seeds = &vec_of_slices[..];
-                if let Ok(_bump) = assert_derivation(&crate::id(), account, seeds) {
+                if let Ok(_bump) = assert_derivation(&crate::ID, account, seeds) {
                     (true, self.to_error())
                 } else {
                     (false, self.to_error())
@@ -284,7 +284,7 @@ impl Rule {
 
                     // Check Frequency account info derivation.
                     let _bump = assert_derivation(
-                        &crate::id(),
+                        &crate::ID,
                         freq_account,
                         &[
                             FREQ_PDA.as_bytes(),

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -105,7 +105,7 @@ impl Rule {
                 if let Some(signer) = accounts.get(account) {
                     (signer.is_signer, self.to_error())
                 } else {
-                    (false, self.to_error())
+                    (false, RuleSetError::MissingAccount)
                 }
             }
             Rule::PubkeyMatch { pubkey, field } => {
@@ -113,7 +113,7 @@ impl Rule {
 
                 let key = match payload.get_pubkey(field) {
                     Some(pubkey) => pubkey,
-                    _ => return (false, self.to_error()),
+                    _ => return (false, RuleSetError::MissingPayloadValue),
                 };
 
                 if key == pubkey {
@@ -127,7 +127,7 @@ impl Rule {
 
                 let seeds = match payload.get_seeds(field) {
                     Some(seeds) => seeds,
-                    _ => return (false, self.to_error()),
+                    _ => return (false, RuleSetError::MissingPayloadValue),
                 };
 
                 let vec_of_slices = seeds
@@ -147,13 +147,15 @@ impl Rule {
 
                 let key = match payload.get_pubkey(field) {
                     Some(pubkey) => pubkey,
-                    _ => return (false, self.to_error()),
+                    _ => return (false, RuleSetError::MissingPayloadValue),
                 };
 
                 if let Some(account) = accounts.get(key) {
                     if *account.owner == *program {
                         return (true, self.to_error());
                     }
+                } else {
+                    return (false, RuleSetError::MissingAccount);
                 }
 
                 (false, self.to_error())
@@ -167,7 +169,7 @@ impl Rule {
                         (false, self.to_error())
                     }
                 } else {
-                    (false, self.to_error())
+                    (false, RuleSetError::MissingPayloadValue)
                 }
             }
             Rule::Frequency {
@@ -200,7 +202,7 @@ impl Rule {
                         (false, self.to_error())
                     }
                 } else {
-                    (false, self.to_error())
+                    (false, RuleSetError::MissingAccount)
                 }
             }
             Rule::PubkeyTreeMatch { root, field } => {
@@ -208,7 +210,7 @@ impl Rule {
 
                 let merkle_proof = match payload.get_merkle_proof(field) {
                     Some(merkle_proof) => merkle_proof,
-                    _ => return (false, self.to_error()),
+                    _ => return (false, RuleSetError::MissingPayloadValue),
                 };
 
                 let mut computed_hash = merkle_proof.leaf;

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -150,7 +150,7 @@ impl Rule {
                     _ => return (false, self.to_error()),
                 };
 
-                if let Some(account) = accounts.get(&key) {
+                if let Some(account) = accounts.get(key) {
                     if *account.owner == *program {
                         return (true, self.to_error());
                     }

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -47,10 +47,19 @@ async fn basic_royalty_enforcement() {
     };
 
     // Create Basic Royalty Enforcement RuleSet.
-    let mut basic_royalty_enforcement_rule_set = RuleSet::new();
-    basic_royalty_enforcement_rule_set.add(Operation::Transfer, owned_by_token_metadata);
-    basic_royalty_enforcement_rule_set.add(Operation::Delegate, leaf_in_marketplace_tree.clone());
-    basic_royalty_enforcement_rule_set.add(Operation::SaleTransfer, leaf_in_marketplace_tree);
+    let mut basic_royalty_enforcement_rule_set = RuleSet::new(
+        "basic_royalty_enforcement".to_string(),
+        context.payer.pubkey(),
+    );
+    basic_royalty_enforcement_rule_set
+        .add(Operation::Transfer, owned_by_token_metadata)
+        .unwrap();
+    basic_royalty_enforcement_rule_set
+        .add(Operation::Delegate, leaf_in_marketplace_tree.clone())
+        .unwrap();
+    basic_royalty_enforcement_rule_set
+        .add(Operation::SaleTransfer, leaf_in_marketplace_tree)
+        .unwrap();
 
     println!(
         "{}",
@@ -68,7 +77,6 @@ async fn basic_royalty_enforcement() {
         mpl_token_auth_rules::id(),
         context.payer.pubkey(),
         rule_set_addr,
-        "basic_royalty_enforcement".to_string(),
         serialized_data,
     );
 
@@ -119,9 +127,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Transfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "basic_royalty_enforcement".to_string(),
         Operation::Transfer,
         payload,
         vec![],
@@ -177,9 +183,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "basic_royalty_enforcement".to_string(),
         Operation::Delegate,
         payload.clone(),
         vec![],
@@ -207,9 +211,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `SaleTransfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "basic_royalty_enforcement".to_string(),
         Operation::SaleTransfer,
         payload,
         vec![],

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -78,6 +78,7 @@ async fn basic_royalty_enforcement() {
         context.payer.pubkey(),
         rule_set_addr,
         serialized_data,
+        vec![],
     );
 
     // Add it to a transaction.

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -35,6 +35,7 @@ async fn test_payer_not_signer_fails() {
         context.payer.pubkey(),
         rule_set_addr,
         vec![],
+        vec![],
     );
 
     // Add it to a non-signed transaction.
@@ -131,6 +132,7 @@ async fn test_additional_signer_and_amount() {
         context.payer.pubkey(),
         rule_set_addr,
         serialized_data,
+        vec![],
     );
 
     // Add it to a transaction.
@@ -183,7 +185,7 @@ async fn test_additional_signer_and_amount() {
             InstructionError::Custom(val),
         )) => {
             let rule_set_error = RuleSetError::from_u32(val).unwrap();
-            assert_eq!(rule_set_error, RuleSetError::AdditionalSignerCheckFailed);
+            assert_eq!(rule_set_error, RuleSetError::MissingAccount);
         }
         _ => panic!("Unexpected error {:?}", err),
     }
@@ -327,6 +329,7 @@ async fn test_frequency() {
         context.payer.pubkey(),
         rule_set_addr,
         serialized_data,
+        vec![freq_account],
     );
 
     // Add it to a transaction.

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -34,7 +34,6 @@ async fn test_payer_not_signer_fails() {
         mpl_token_auth_rules::id(),
         context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         vec![],
     );
 
@@ -57,9 +56,7 @@ async fn test_payer_not_signer_fails() {
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         Operation::Transfer,
         Payload::default(),
         vec![],
@@ -117,8 +114,8 @@ async fn test_additional_signer_and_amount() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSet::new();
-    rule_set.add(Operation::Transfer, overall_rule);
+    let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set.add(Operation::Transfer, overall_rule).unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -133,7 +130,6 @@ async fn test_additional_signer_and_amount() {
         mpl_token_auth_rules::id(),
         context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         serialized_data,
     );
 
@@ -158,12 +154,10 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITHOUT the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         Operation::Transfer,
         payload.clone(),
-        vec![],
+        vec![context.payer.pubkey()],
         vec![],
     );
 
@@ -197,12 +191,10 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         Operation::Transfer,
         payload,
-        vec![second_signer.pubkey()],
+        vec![context.payer.pubkey(), second_signer.pubkey()],
         vec![],
     );
 
@@ -227,12 +219,10 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         Operation::Transfer,
         payload,
-        vec![second_signer.pubkey()],
+        vec![context.payer.pubkey(), second_signer.pubkey()],
         vec![],
     );
 
@@ -320,8 +310,8 @@ async fn test_frequency() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSet::new();
-    rule_set.add(Operation::Transfer, freq_rule);
+    let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set.add(Operation::Transfer, freq_rule).unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -336,7 +326,6 @@ async fn test_frequency() {
         mpl_token_auth_rules::id(),
         context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         serialized_data,
     );
 
@@ -364,9 +353,7 @@ async fn test_frequency() {
     // Create a `validate` instruction passing in the Frequency Rule account.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         mpl_token_auth_rules::id(),
-        context.payer.pubkey(),
         rule_set_addr,
-        "test rule_set".to_string(),
         Operation::Transfer,
         Payload::default(),
         vec![],


### PR DESCRIPTION
### Notes
* Remove need for payer to sign the validate instruction.
* Add verification that program owns the RuleSet PDA and data length is nonzero.
* Update to use constant crate ID.
* Regenerate SDK.


### UPDATE
* Store name and owner of RuleSet in the RuleSet PDA.
* Add errors for missing accounts and missing payload values.
* Add optional accounts to create instruction.
 * These are used to pass in PDAs that will be validated before
the RuleSet is stored.
 * Currently this would only apply to the Frequency Rule.
 * Add verification that program owns the Frequency PDA and data length is nonzero.
 * Regenerating SDK.
 * Docs update in: https://github.com/metaplex-foundation/mpl-token-auth-rules/pull/35
### Testing
```
cargo build-bpf
cargo test-bpf
```