### PR TITLE
Improve `Payload` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are **Primitive Rules** and **Composed Rules** that are created by combini
 **Note: Additional Rust examples can be found in the [program/tests](https://github.com/metaplex-foundation/mpl-token-auth-rules/tree/main/program/tests) directory.**
 ```rust
 use mpl_token_auth_rules::{
-    payload::{Payload, PayloadKey, PayloadTyp},
+    payload::{Payload, PayloadKey, PayloadType},
     state::{Operation, Rule, RuleSet},
 };
 use rmp_serde::Serializer;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are **Primitive Rules** and **Composed Rules** that are created by combini
 **Note: Additional Rust examples can be found in the [program/tests](https://github.com/metaplex-foundation/mpl-token-auth-rules/tree/main/program/tests) directory.**
 ```rust
 use mpl_token_auth_rules::{
-    payload::{PayloadKey, PayloadType},
+    payload::{Payload, PayloadKey, PayloadTyp},
     state::{Operation, Rule, RuleSet},
 };
 use rmp_serde::Serializer;
@@ -28,7 +28,6 @@ use solana_sdk::{
     native_token::LAMPORTS_PER_SOL, signature::Signer, signer::keypair::Keypair,
     transaction::Transaction,
 };
-use std::collections::HashMap;
 
 fn main() {
     let url = "https://api.devnet.solana.com".to_string();
@@ -110,7 +109,7 @@ fn main() {
     println!("Create tx signature: {}", signature);
 
     // Store the payload of data to validate against the rule definition.
-    let payload = HashMap::from([(PayloadKey::Amount, PayloadType::Number(2))]);
+    let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(2))]);
 
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(

--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "name": "mpl_token_auth_rules",
   "instructions": [
     {
@@ -496,6 +496,11 @@
       "code": 14,
       "name": "BorshSerializationError",
       "msg": "Borsh Serialization Error"
+    },
+    {
+      "code": 15,
+      "name": "PayloadValueOccupied",
+      "msg": "Value in Payload is occupied"
     }
   ],
   "metadata": {

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -321,6 +321,26 @@ createErrorFromCodeLookup.set(0xe, () => new BorshSerializationErrorError());
 createErrorFromNameLookup.set('BorshSerializationError', () => new BorshSerializationErrorError());
 
 /**
+ * PayloadValueOccupied: 'Value in Payload is occupied'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class PayloadValueOccupiedError extends Error {
+  readonly code: number = 0xf;
+  readonly name: string = 'PayloadValueOccupied';
+  constructor() {
+    super('Value in Payload is occupied');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, PayloadValueOccupiedError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0xf, () => new PayloadValueOccupiedError());
+createErrorFromNameLookup.set('PayloadValueOccupied', () => new PayloadValueOccupiedError());
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -67,6 +67,10 @@ pub enum RuleSetError {
     /// 14 - Borsh Serialization Error
     #[error("Borsh Serialization Error")]
     BorshSerializationError,
+
+    /// 15 - Value in Payload is occupied
+    #[error("Value in Payload is occupied")]
+    PayloadValueOccupied,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,14 +1,10 @@
-use crate::{
-    payload::{Payload, PayloadKey, PayloadType},
-    state::Operation,
-};
+use crate::{payload::Payload, state::Operation};
 use borsh::{BorshDeserialize, BorshSerialize};
 use shank::ShankInstruction;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
 };
-use std::collections::HashMap;
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
@@ -113,7 +109,7 @@ pub fn validate(
     rule_set_pda: Pubkey,
     rule_set_name: String,
     operation: Operation,
-    payload: HashMap<PayloadKey, PayloadType>,
+    payload: Payload,
     rule_signer_accounts: Vec<Pubkey>,
     rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
@@ -149,7 +145,7 @@ pub fn validate(
         data: RuleSetInstruction::Validate(ValidateArgs {
             rule_set_name,
             operation,
-            payload: Payload::from(payload),
+            payload,
         })
         .try_to_vec()
         .unwrap(),

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -116,7 +116,7 @@ impl Rule {
                     _ => return (false, self.to_error()),
                 };
 
-                if key == *pubkey {
+                if key == pubkey {
                     (true, self.to_error())
                 } else {
                     (false, self.to_error())

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -3,7 +3,7 @@
 pub mod utils;
 
 use mpl_token_auth_rules::{
-    payload::{LeafInfo, PayloadKey, PayloadType},
+    payload::{LeafInfo, Payload, PayloadKey, PayloadType},
     state::{Operation, Rule, RuleSet},
 };
 use rmp_serde::Serializer;
@@ -12,7 +12,6 @@ use solana_program_test::tokio;
 use solana_sdk::{
     signature::Signer, signer::keypair::Keypair, system_instruction, transaction::Transaction,
 };
-use std::collections::HashMap;
 use utils::program_test;
 
 #[tokio::test]
@@ -112,7 +111,7 @@ async fn basic_royalty_enforcement() {
     // Store the payload of data to validate against the rule definition.
     // In this case the Target will be used to look up the `AccountInfo`
     // and see who the owner is.
-    let payload = HashMap::from([(
+    let payload = Payload::from([(
         PayloadKey::Target,
         PayloadType::Pubkey(fake_token_metadata_owned_escrow.pubkey()),
     )]);
@@ -173,7 +172,7 @@ async fn basic_royalty_enforcement() {
 
     // Store the payload of data to validate against the rule definition.
     // In this case it is a leaf node and its associated Merkle proof.
-    let payload = HashMap::from([(PayloadKey::Target, PayloadType::MerkleProof(leaf_info))]);
+    let payload = Payload::from([(PayloadKey::Target, PayloadType::MerkleProof(leaf_info))]);
 
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -4,7 +4,7 @@ pub mod utils;
 
 use mpl_token_auth_rules::{
     error::RuleSetError,
-    payload::{PayloadKey, PayloadType},
+    payload::{Payload, PayloadKey, PayloadType},
     state::{Operation, Rule, RuleSet},
 };
 use num_traits::cast::FromPrimitive;
@@ -17,7 +17,6 @@ use solana_sdk::{
     signer::keypair::Keypair,
     transaction::{Transaction, TransactionError},
 };
-use std::collections::HashMap;
 use utils::program_test;
 
 #[tokio::test]
@@ -62,7 +61,7 @@ async fn test_payer_not_signer_fails() {
         rule_set_addr,
         "test rule_set".to_string(),
         Operation::Transfer,
-        HashMap::default(),
+        Payload::default(),
         vec![],
         vec![],
     );
@@ -154,7 +153,7 @@ async fn test_additional_signer_and_amount() {
         .expect("creation should succeed");
 
     // Store the payload of data to validate against the rule definition.
-    let payload = HashMap::from([(PayloadKey::Amount, PayloadType::Number(2))]);
+    let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(2))]);
 
     // Create a `validate` instruction WITHOUT the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
@@ -223,7 +222,7 @@ async fn test_additional_signer_and_amount() {
         .expect("validation should succeed");
 
     // Store a payload of data with the WRONG amount.
-    let payload = HashMap::from([(PayloadKey::Amount, PayloadType::Number(1))]);
+    let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(1))]);
 
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
@@ -369,7 +368,7 @@ async fn test_frequency() {
         rule_set_addr,
         "test rule_set".to_string(),
         Operation::Transfer,
-        HashMap::default(),
+        Payload::default(),
         vec![],
         vec![freq_account],
     );


### PR DESCRIPTION
### Notes
* Add pub function to allow creating Pubkey from an array of tuples.
* Add pub functions for insert, try insert, and get.
* Add doc comments for all Pubkey functions.
* Remove clone/copy from get functions by returning references (except u64).
* Modify instruction builder to take Payload type.

### Testing
```
cargo build-bpf
cargo test-bpf
```