### PR TITLE
Modify `SolanaAccount` trait and Frequency rule update on pass

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -22,6 +22,8 @@ pub struct ValidateArgs {
     pub operation: u16,
     /// `Payload` data used for rule validation.
     pub payload: Payload,
+    /// Update any relevant state stored in Rule, such as the Frequency `last_update` time value.
+    pub update_rule_state: bool,
 }
 
 #[repr(C)]
@@ -117,6 +119,7 @@ pub fn validate(
     rule_set_pda: Pubkey,
     operation: u16,
     payload: Payload,
+    update_rule_state: bool,
     rule_signer_accounts: Vec<Pubkey>,
     rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
@@ -148,9 +151,13 @@ pub fn validate(
     Instruction {
         program_id,
         accounts,
-        data: RuleSetInstruction::Validate(ValidateArgs { operation, payload })
-            .try_to_vec()
-            .unwrap(),
+        data: RuleSetInstruction::Validate(ValidateArgs {
+            operation,
+            payload,
+            update_rule_state,
+        })
+        .try_to_vec()
+        .unwrap(),
     }
 }
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -59,16 +59,16 @@ pub enum RuleSetInstruction {
     /// it an `AccountsMap` and a `PayloadMap` and calling the `RuleSet`'s `validate` method.
     #[account(0, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
     #[account(1, name = "system_program", desc = "System program")]
-    #[account(2, optional, signer, name="opt_rule_signer_1", desc = "Optional rule validation signer 1")]
-    #[account(3, optional, signer, name="opt_rule_signer_2", desc = "Optional rule validation signer 2")]
-    #[account(4, optional, signer, name="opt_rule_signer_3", desc = "Optional rule validation signer 3")]
-    #[account(5, optional, signer, name="opt_rule_signer_4", desc = "Optional rule validation signer 4")]
-    #[account(6, optional, signer, name="opt_rule_signer_5", desc = "Optional rule validation signer 5")]
-    #[account(7, optional, name = "opt_rule_nonsigner_1", desc = "Optional rule validation non-signer 1")]
-    #[account(8, optional, name = "opt_rule_nonsigner_2", desc = "Optional rule validation non-signer 2")]
-    #[account(9, optional, name = "opt_rule_nonsigner_3", desc = "Optional rule validation non-signer 3")]
-    #[account(10, optional, name = "opt_rule_nonsigner_4", desc = "Optional rule validation non-signer 4")]
-    #[account(11, optional, name = "opt_rule_nonsigner_5", desc = "Optional rule validation non-signer 5")]
+    #[account(2, optional, writable, signer, name="opt_rule_signer_1", desc = "Optional rule validation signer 1")]
+    #[account(3, optional, writable, signer, name="opt_rule_signer_2", desc = "Optional rule validation signer 2")]
+    #[account(4, optional, writable, signer, name="opt_rule_signer_3", desc = "Optional rule validation signer 3")]
+    #[account(5, optional, writable, signer, name="opt_rule_signer_4", desc = "Optional rule validation signer 4")]
+    #[account(6, optional, writable, signer, name="opt_rule_signer_5", desc = "Optional rule validation signer 5")]
+    #[account(7, optional, writable, name = "opt_rule_nonsigner_1", desc = "Optional rule validation non-signer 1")]
+    #[account(8, optional, writable, name = "opt_rule_nonsigner_2", desc = "Optional rule validation non-signer 2")]
+    #[account(9, optional, writable, name = "opt_rule_nonsigner_3", desc = "Optional rule validation non-signer 3")]
+    #[account(10, optional, writable, name = "opt_rule_nonsigner_4", desc = "Optional rule validation non-signer 4")]
+    #[account(11, optional, writable, name = "opt_rule_nonsigner_5", desc = "Optional rule validation non-signer 5")]
     Validate(ValidateArgs),
 
     /// This instruction stores a Frequency Rule into a Frequency Rule PDA account.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -127,7 +127,7 @@ pub fn validate(
 
     for i in 0..5 {
         if let Some(account) = rule_signer_accounts.get(i) {
-            accounts.push(AccountMeta::new_readonly(*account, true));
+            accounts.push(AccountMeta::new(*account, true));
         }
     }
 
@@ -137,7 +137,7 @@ pub fn validate(
 
     for i in 0..5 {
         if let Some(account) = rule_nonsigner_accounts.get(i) {
-            accounts.push(AccountMeta::new_readonly(*account, false));
+            accounts.push(AccountMeta::new(*account, false));
         }
     }
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -55,7 +55,7 @@ pub enum RuleSetInstruction {
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by sending
     /// it an `AccountsMap` and a `PayloadMap` and calling the `RuleSet`'s `validate` method.
-    #[account(0, writable, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
+    #[account(0, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
     #[account(1, name = "system_program", desc = "System program")]
     #[account(2, optional, signer, name="opt_rule_signer_1", desc = "Optional rule validation signer 1")]
     #[account(3, optional, signer, name="opt_rule_signer_2", desc = "Optional rule validation signer 2")]
@@ -121,7 +121,7 @@ pub fn validate(
     rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(rule_set_pda, false),
+        AccountMeta::new_readonly(rule_set_pda, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -151,7 +151,9 @@ impl Processor {
                     .ok_or(RuleSetError::OperationNotFound)?;
 
                 // Validate the Rule.
-                if let Err(err) = rule.validate(&accounts_map, &args.payload) {
+                if let Err(err) =
+                    rule.validate(&accounts_map, &args.payload, args.update_rule_state)
+                {
                     msg!("Failed to validate: {}", err);
                     return Err(err);
                 }

--- a/program/src/state/frequency.rs
+++ b/program/src/state/frequency.rs
@@ -24,10 +24,4 @@ impl SolanaAccount for FrequencyAccount {
     fn key() -> Key {
         Key::Frequency
     }
-
-    fn size() -> usize {
-        1   // key
-        + 8 // last_update
-        + 8 // period
-    }
 }

--- a/program/src/state/frequency.rs
+++ b/program/src/state/frequency.rs
@@ -26,6 +26,8 @@ impl SolanaAccount for FrequencyAccount {
     }
 
     fn size() -> usize {
-        0
+        1   // key
+        + 8 // last_update
+        + 8 // period
     }
 }

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,9 +1,9 @@
-use std::io::ErrorKind;
-
-use borsh::{maybestd::io::Error as BorshError, BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use solana_program::{account_info::AccountInfo, program_error::ProgramError};
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
+};
 
 mod frequency;
 mod rule_set;
@@ -22,45 +22,52 @@ pub enum Key {
     Frequency,
 }
 
-pub trait SolanaAccount: BorshDeserialize {
+pub trait SolanaAccount: BorshSerialize + BorshDeserialize {
+    /// Get the `Key` for this `Account`.  This key is to be stored in the first byte of the
+    /// `Account` data.
     fn key() -> Key;
 
+    /// Get the size of the `Account` data.
     fn size() -> usize;
 
-    fn is_correct_account_type(data: &[u8], data_type: Key) -> bool {
-        let key: Option<Key> = Key::from_u8(data[0]);
+    /// BorshDeserialize the `AccountInfo` into the Rust data structure.
+    fn from_account_info(account: &AccountInfo) -> Result<Self, ProgramError> {
+        let data = account
+            .data
+            .try_borrow()
+            .map_err(|_| ProgramError::AccountBorrowFailed)?;
+
+        if !Self::is_correct_account_type_and_size(&data, Self::key(), Self::size()) {
+            return Err(RuleSetError::DataTypeMismatch.into());
+        }
+
+        let data = Self::try_from_slice(&data)?;
+
+        // Check that this account is owned by this program.
+        assert_owned_by(account, &crate::ID)?;
+
+        Ok(data)
+    }
+
+    /// BorshSerialize the Rust data structure into the `Account` data.
+    fn to_account_data(&self, account: &AccountInfo) -> ProgramResult {
+        let mut data = account.try_borrow_mut_data()?;
+        self.serialize(&mut *data).map_err(Into::into)
+    }
+}
+
+trait PrivateSolanaAccountMethods: SolanaAccount {
+    const KEY_BYTE: usize = 0;
+
+    // Check the `Key` byte and the data size to determine if this data represents the correct
+    // account types.
+    fn is_correct_account_type_and_size(data: &[u8], data_type: Key, data_size: usize) -> bool {
+        let key: Option<Key> = Key::from_u8(data[Self::KEY_BYTE]);
         match key {
-            Some(key) => key == data_type || key == Key::Uninitialized,
+            Some(key) => key == data_type && data.len() == data_size,
             None => false,
         }
     }
-
-    fn pad_length(buf: &mut Vec<u8>) -> Result<(), RuleSetError> {
-        let padding_length = Self::size()
-            .checked_sub(buf.len())
-            .ok_or(RuleSetError::NumericalOverflow)?;
-        buf.extend(vec![0; padding_length]);
-        Ok(())
-    }
-
-    fn safe_deserialize(mut data: &[u8]) -> Result<Self, BorshError> {
-        if !Self::is_correct_account_type(data, Self::key()) {
-            return Err(BorshError::new(ErrorKind::Other, "DataTypeMismatch"));
-        }
-
-        let result = Self::deserialize(&mut data)?;
-
-        Ok(result)
-    }
-
-    fn from_account_info(a: &AccountInfo) -> Result<Self, ProgramError>
-where {
-        let ua = Self::safe_deserialize(&a.data.borrow_mut())
-            .map_err(|_| RuleSetError::DataTypeMismatch)?;
-
-        // Check that this account is owned by this program.
-        assert_owned_by(a, &crate::ID)?;
-
-        Ok(ua)
-    }
 }
+
+impl<T: SolanaAccount> PrivateSolanaAccountMethods for T {}

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -27,9 +27,6 @@ pub trait SolanaAccount: BorshSerialize + BorshDeserialize {
     /// `Account` data.
     fn key() -> Key;
 
-    /// Get the size of the `Account` data.
-    fn size() -> usize;
-
     /// BorshDeserialize the `AccountInfo` into the Rust data structure.
     fn from_account_info(account: &AccountInfo) -> Result<Self, ProgramError> {
         let data = account
@@ -37,7 +34,7 @@ pub trait SolanaAccount: BorshSerialize + BorshDeserialize {
             .try_borrow()
             .map_err(|_| ProgramError::AccountBorrowFailed)?;
 
-        if !Self::is_correct_account_type_and_size(&data, Self::key(), Self::size()) {
+        if !Self::is_correct_account_type_and_size(&data, Self::key()) {
             return Err(RuleSetError::DataTypeMismatch.into());
         }
 
@@ -61,10 +58,10 @@ trait PrivateSolanaAccountMethods: SolanaAccount {
 
     // Check the `Key` byte and the data size to determine if this data represents the correct
     // account types.
-    fn is_correct_account_type_and_size(data: &[u8], data_type: Key, data_size: usize) -> bool {
+    fn is_correct_account_type_and_size(data: &[u8], data_type: Key) -> bool {
         let key: Option<Key> = Key::from_u8(data[Self::KEY_BYTE]);
         match key {
-            Some(key) => key == data_type && data.len() == data_size,
+            Some(key) => key == data_type,
             None => false,
         }
     }

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -141,6 +141,7 @@ async fn basic_royalty_enforcement() {
         rule_set_addr,
         Operation::Transfer.to_u16().unwrap(),
         payload,
+        true,
         vec![],
         vec![fake_token_metadata_owned_escrow.pubkey()],
     );
@@ -197,6 +198,7 @@ async fn basic_royalty_enforcement() {
         rule_set_addr,
         Operation::Delegate.to_u16().unwrap(),
         payload.clone(),
+        true,
         vec![],
         vec![],
     );
@@ -225,6 +227,7 @@ async fn basic_royalty_enforcement() {
         rule_set_addr,
         Operation::SaleTransfer.to_u16().unwrap(),
         payload,
+        true,
         vec![],
         vec![],
     );

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -61,6 +61,7 @@ async fn test_payer_not_signer_fails() {
         rule_set_addr,
         Operation::Transfer.to_u16().unwrap(),
         Payload::default(),
+        true,
         vec![],
         vec![],
     );
@@ -162,6 +163,7 @@ async fn test_additional_signer_and_amount() {
         rule_set_addr,
         Operation::Transfer.to_u16().unwrap(),
         payload.clone(),
+        true,
         vec![context.payer.pubkey()],
         vec![],
     );
@@ -199,6 +201,7 @@ async fn test_additional_signer_and_amount() {
         rule_set_addr,
         Operation::Transfer.to_u16().unwrap(),
         payload,
+        true,
         vec![context.payer.pubkey(), second_signer.pubkey()],
         vec![],
     );
@@ -227,6 +230,7 @@ async fn test_additional_signer_and_amount() {
         rule_set_addr,
         Operation::Transfer.to_u16().unwrap(),
         payload,
+        true,
         vec![context.payer.pubkey(), second_signer.pubkey()],
         vec![],
     );
@@ -364,6 +368,7 @@ async fn test_frequency() {
         rule_set_addr,
         Operation::Transfer.to_u16().unwrap(),
         Payload::default(),
+        true,
         vec![],
         vec![freq_account],
     );


### PR DESCRIPTION
### Notes
* Modify SolanaAccount trait for our use case.
  * Remove unused trait methods.
  * Privatize one function.
  * Modify `is_correct_account_type` to also check size.
* Modify Frequency rule validation to update data.
* Update the last_update field to current time.
* Make RuleSet PDA account read only during validate.
* Cleanup names and flatten if/else structure in Frequency rule.

### UPDATE
* Add boolean flag to validate for updating Rule state.
  * This flag tells validate to update any relevant state stored in Rule, such as the Frequency `last_update` time value.
* Remove size check on frequency account data per PR comment.

### Discussion
Do we need to use SolanaAccount 1-byte discriminator and size check given that we are following the pattern of validating PDAs?

### Testing
```
cargo build-bpf
cargo test-bpf
```