### PR TITLE
Add `rule_set_state` PDA and remove Frequency rule PDA

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -103,6 +103,10 @@ pub enum RuleSetError {
     /// 22 - Name too long
     #[error("The operation retrieved is not in the selected RuleSet")]
     OperationNotFound,
+
+    /// 22 - Rule authority is not signer
+    #[error("Rule authority is not signer")]
+    RuleAuthorityIsNotSigner,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -107,10 +107,6 @@ pub enum RuleSetError {
     /// 24 - Rule authority is not signer
     #[error("Rule authority is not signer")]
     RuleAuthorityIsNotSigner,
-
-    /// 25 - Too many accounts were provided
-    #[error("Too many accounts were provided")]
-    TooManyAccountKeys,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -100,13 +100,17 @@ pub enum RuleSetError {
     #[error("Name too long")]
     NameTooLong,
 
-    /// 22 - Name too long
+    /// 23 - Name too long
     #[error("The operation retrieved is not in the selected RuleSet")]
     OperationNotFound,
 
-    /// 22 - Rule authority is not signer
+    /// 24 - Rule authority is not signer
     #[error("Rule authority is not signer")]
     RuleAuthorityIsNotSigner,
+
+    /// 25 - Too many accounts were provided
+    #[error("Too many accounts were provided")]
+    TooManyAccountKeys,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -52,15 +52,11 @@ pub enum RuleSetInstruction {
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by sending
     /// it an `AccountsMap` and a `PayloadMap` and calling the `RuleSet`'s `validate` method.
-    #[account(0, name="rule_set", desc = "The PDA account where the RuleSet is stored")]
-    #[account(1, name = "system_program", desc = "System program")]
+    #[account(0, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
+    #[account(1, writable, name="rule_set_state_pda", desc = "The PDA account where any RuleSet state is stored")]
+    #[account(2, name="mint", desc="Mint of token asset")]
+    #[account(3, name = "system_program", desc = "System program")]
     Validate(ValidateArgs),
-
-    /// This instruction stores a Frequency Rule into a Frequency Rule PDA account.
-    #[account(0, writable, signer, name="payer", desc="Payer and creator of the Frequency Rule")]
-    #[account(1, writable, name="frequency_pda", desc = "The PDA account where the Frequency Rule is stored")]
-    #[account(2, name = "system_program", desc = "System program")]
-    CreateFrequencyRule(CreateFrequencyRuleArgs),
 }
 /// Builds a `create` instruction.
 pub fn create(
@@ -94,6 +90,8 @@ pub fn create(
 #[allow(clippy::too_many_arguments)]
 pub fn validate(
     rule_set_pda: Pubkey,
+    rule_set_state_pda: Pubkey,
+    mint: Pubkey,
     operation: String,
     payload: Payload,
     update_rule_state: bool,
@@ -101,6 +99,8 @@ pub fn validate(
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new_readonly(rule_set_pda, false),
+        AccountMeta::new_readonly(rule_set_state_pda, false),
+        AccountMeta::new(mint, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
 
@@ -113,35 +113,6 @@ pub fn validate(
             operation,
             payload,
             update_rule_state,
-        })
-        .try_to_vec()
-        .unwrap(),
-    }
-}
-
-/// Builds a `create_frequency_rule` instruction.
-pub fn create_frequency_rule(
-    payer: Pubkey,
-    freq_rule_pda: Pubkey,
-    rule_set_name: String,
-    freq_rule_name: String,
-    last_update: i64,
-    period: i64,
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new(payer, true),
-        AccountMeta::new(freq_rule_pda, false),
-        AccountMeta::new_readonly(solana_program::system_program::id(), false),
-    ];
-
-    Instruction {
-        program_id: crate::ID,
-        accounts,
-        data: RuleSetInstruction::CreateFrequencyRule(CreateFrequencyRuleArgs {
-            rule_set_name,
-            freq_rule_name,
-            last_update,
-            period,
         })
         .try_to_vec()
         .unwrap(),

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -26,20 +26,6 @@ pub struct ValidateArgs {
     pub update_rule_state: bool,
 }
 
-#[repr(C)]
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
-/// Args for `create_frequency_rule` instruction.
-pub struct CreateFrequencyRuleArgs {
-    /// Name of the RuleSet, used in PDA derivation.
-    pub rule_set_name: String,
-    /// Name of the Frequency Rule, used in Frequency PDA derivation.
-    pub freq_rule_name: String,
-    /// Timestamp of last update.
-    pub last_update: i64,
-    /// Timestamp of permitted period.
-    pub period: i64,
-}
-
 #[derive(Debug, Clone, ShankInstruction, BorshSerialize, BorshDeserialize)]
 #[rustfmt::skip]
 /// Instructions available in this program.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -31,22 +31,23 @@ pub struct ValidateArgs {
 /// Instructions available in this program.
 pub enum RuleSetInstruction {
     /// This instruction stores a caller-pre-serialized `RuleSet` into the rule_set PDA account.
-    #[account(0, writable, signer, name="payer", desc="Payer and creator of the RuleSet")]
+    #[account(0, signer, writable, name="payer", desc="Payer and creator of the RuleSet")]
     #[account(1, writable, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
     Create(CreateArgs),
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by calling the
     /// `RuleSet`'s `validate` method.  If any of the Rules contained in the RuleSet have state
-    /// information (such as the Frequency rule's `last_update` time value, it is saved in the
-    /// RuleSet state PDA as long as the `rule_authority` signer matches the Pubkey stored in the
-    /// Rule.
-    #[account(0, writable, signer, name="payer", desc="Payer for RuleSet state PDA account")]
-    #[account(1, signer, name="rule_authority", desc="Signing authority for any Rule state updates")]
-    #[account(2, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
-    #[account(3, writable, name="rule_set_state_pda", desc = "The PDA account where any RuleSet state is stored")]
-    #[account(4, name="mint", desc="Mint of token asset")]
-    #[account(5, name = "system_program", desc = "System program")]
+    /// information (such as the Frequency rule's `last_update` time value), the optional accounts
+    /// must be provided in order to save the updated stated in the RuleSet state PDA.  Note that
+    /// updating the state for a Rule requires that the `rule_authority` signer matches the Pubkey
+    /// stored in the Rule.
+    #[account(0, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
+    #[account(1, name="mint", desc="Mint of token asset")]
+    #[account(2, name = "system_program", desc = "System program")]
+    #[account(3, optional, signer, writable, name="payer", desc="Payer for RuleSet state PDA account")]
+    #[account(4, optional, signer, name="rule_authority", desc="Signing authority for any Rule state updates")]
+    #[account(5, optional, writable, name="rule_set_state_pda", desc = "The PDA account where any RuleSet state is stored")]
     Validate(ValidateArgs),
 }
 /// Builds a `create` instruction.
@@ -80,24 +81,33 @@ pub fn create(
 /// Builds a `validate` instruction.
 #[allow(clippy::too_many_arguments)]
 pub fn validate(
-    payer: Pubkey,
-    rule_authority: Pubkey,
     rule_set_pda: Pubkey,
-    rule_set_state_pda: Pubkey,
     mint: Pubkey,
+    payer: Option<Pubkey>,
+    rule_authority: Option<Pubkey>,
+    rule_set_state_pda: Option<Pubkey>,
     operation: String,
     payload: Payload,
     update_rule_state: bool,
     additional_rule_accounts: Vec<AccountMeta>,
 ) -> Instruction {
     let mut accounts = vec![
-        AccountMeta::new(payer, true),
-        AccountMeta::new_readonly(rule_authority, true),
         AccountMeta::new_readonly(rule_set_pda, false),
-        AccountMeta::new(rule_set_state_pda, false),
         AccountMeta::new_readonly(mint, false),
         AccountMeta::new_readonly(solana_program::system_program::id(), false),
     ];
+
+    if let Some(payer) = payer {
+        accounts.push(AccountMeta::new(payer, true));
+    }
+
+    if let Some(rule_authority) = rule_authority {
+        accounts.push(AccountMeta::new_readonly(rule_authority, true));
+    }
+
+    if let Some(rule_set_state_pda) = rule_set_state_pda {
+        accounts.push(AccountMeta::new(rule_set_state_pda, false));
+    }
 
     accounts.extend(additional_rule_accounts);
 

--- a/program/src/pda.rs
+++ b/program/src/pda.rs
@@ -1,7 +1,7 @@
 use solana_program::pubkey::Pubkey;
 
 pub const PREFIX: &str = "rule_set";
-pub const FREQ_PDA: &str = "frequency";
+pub const STATE_PDA: &str = "rule_set_state";
 
 pub fn find_rule_set_address(creator: Pubkey, rule_set_name: String) -> (Pubkey, u8) {
     Pubkey::find_program_address(
@@ -14,17 +14,17 @@ pub fn find_rule_set_address(creator: Pubkey, rule_set_name: String) -> (Pubkey,
     )
 }
 
-pub fn find_frequency_pda_address(
+pub fn find_rule_set_state_address(
     creator: Pubkey,
     rule_set_name: String,
-    freq_rule_name: String,
+    mint: Pubkey,
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(
         &[
-            FREQ_PDA.as_bytes(),
+            STATE_PDA.as_bytes(),
             creator.as_ref(),
             rule_set_name.as_bytes(),
-            freq_rule_name.as_bytes(),
+            mint.as_ref(),
         ],
         &crate::ID,
     )

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -88,10 +88,22 @@ impl Processor {
             }
             RuleSetInstruction::Validate(args) => {
                 let account_info_iter = &mut accounts.iter();
+                let payer_info = next_account_info(account_info_iter)?;
+                let rule_authority_info = next_account_info(account_info_iter)?;
                 let rule_set_pda_info = next_account_info(account_info_iter)?;
                 let rule_set_state_pda_info = next_account_info(account_info_iter)?;
                 let mint_info = next_account_info(account_info_iter)?;
                 let _system_program_info = next_account_info(account_info_iter)?;
+
+                if args.update_rule_state {
+                    if !payer_info.is_signer {
+                        return Err(RuleSetError::PayerIsNotSigner.into());
+                    }
+
+                    if !rule_authority_info.is_signer {
+                        return Err(RuleSetError::RuleAuthorityIsNotSigner.into());
+                    }
+                }
 
                 // RuleSet must be owned by this program.
                 if *rule_set_pda_info.owner != crate::ID {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -89,20 +89,14 @@ impl Processor {
             RuleSetInstruction::Validate(args) => {
                 let account_info_iter = &mut accounts.iter();
                 let payer_info = next_account_info(account_info_iter)?;
-                let rule_authority_info = next_account_info(account_info_iter)?;
+                let _rule_authority_info = next_account_info(account_info_iter)?;
                 let rule_set_pda_info = next_account_info(account_info_iter)?;
                 let rule_set_state_pda_info = next_account_info(account_info_iter)?;
                 let mint_info = next_account_info(account_info_iter)?;
                 let _system_program_info = next_account_info(account_info_iter)?;
 
-                if args.update_rule_state {
-                    if !payer_info.is_signer {
-                        return Err(RuleSetError::PayerIsNotSigner.into());
-                    }
-
-                    if !rule_authority_info.is_signer {
-                        return Err(RuleSetError::RuleAuthorityIsNotSigner.into());
-                    }
+                if args.update_rule_state && !payer_info.is_signer {
+                    return Err(RuleSetError::PayerIsNotSigner.into());
                 }
 
                 // RuleSet must be owned by this program.

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -57,7 +57,9 @@ pub enum Rule {
         amount: u64,
         operator: CompareOp,
     },
-    Frequency,
+    Frequency {
+        authority: Pubkey,
+    },
     Pass,
 }
 
@@ -250,8 +252,15 @@ impl Rule {
                     (false, RuleSetError::MissingPayloadValue.into())
                 }
             }
-            Rule::Frequency => {
+            Rule::Frequency { authority } => {
                 msg!("Validating Frequency");
+
+                if let Some(account) = accounts.get(authority) {
+                    if !account.is_signer {
+                        return (false, RuleSetError::RuleAuthorityIsNotSigner.into());
+                    }
+                }
+
                 (false, RuleSetError::NotImplemented.into())
             }
             Rule::Pass => {

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -259,6 +259,8 @@ impl Rule {
                     if !account.is_signer {
                         return (false, RuleSetError::RuleAuthorityIsNotSigner.into());
                     }
+                } else {
+                    return (false, RuleSetError::MissingAccount.into());
                 }
 
                 (false, RuleSetError::NotImplemented.into())

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -85,8 +85,8 @@ impl Rule {
         &self,
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
-        update_rule_state: bool,
-        state_pda: Option<&Pubkey>,
+        _update_rule_state: bool,
+        _state_pda: Option<&Pubkey>,
     ) -> (bool, ProgramError) {
         match self {
             Rule::All { rules } => {
@@ -95,7 +95,7 @@ impl Rule {
                 for rule in rules {
                     last = rule.to_error();
                     let result =
-                        rule.low_level_validate(accounts, payload, update_rule_state, state_pda);
+                        rule.low_level_validate(accounts, payload, _update_rule_state, _state_pda);
                     if !result.0 {
                         return result;
                     }
@@ -108,7 +108,7 @@ impl Rule {
                 for rule in rules {
                     last = rule.to_error();
                     let result =
-                        rule.low_level_validate(accounts, payload, update_rule_state, state_pda);
+                        rule.low_level_validate(accounts, payload, _update_rule_state, _state_pda);
                     if result.0 {
                         return result;
                     }
@@ -117,7 +117,7 @@ impl Rule {
             }
             Rule::Not { rule } => {
                 let result =
-                    rule.low_level_validate(accounts, payload, update_rule_state, state_pda);
+                    rule.low_level_validate(accounts, payload, _update_rule_state, _state_pda);
                 (!result.0, result.1)
             }
             Rule::AdditionalSigner { account } => {

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -69,7 +69,7 @@ impl Rule {
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
         update_rule_state: bool,
-        state_pda: &Pubkey,
+        state_pda: Option<&Pubkey>,
     ) -> ProgramResult {
         let (status, rollup_err) =
             self.low_level_validate(accounts, payload, update_rule_state, state_pda);
@@ -86,7 +86,7 @@ impl Rule {
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
         update_rule_state: bool,
-        state_pda: &Pubkey,
+        state_pda: Option<&Pubkey>,
     ) -> (bool, ProgramError) {
         match self {
             Rule::All { rules } => {

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -1,17 +1,14 @@
 use crate::{
     error::RuleSetError,
     payload::{Payload, PayloadKey},
-    pda::FREQ_PDA,
     utils::assert_derivation,
 };
 use serde::{Deserialize, Serialize};
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
-    pubkey::Pubkey, sysvar::Sysvar,
+    pubkey::Pubkey,
 };
 use std::collections::HashMap;
-
-use super::{FrequencyAccount, SolanaAccount};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum CompareOp {
@@ -60,10 +57,7 @@ pub enum Rule {
         amount: u64,
         operator: CompareOp,
     },
-    Frequency {
-        freq_name: String,
-        freq_account: Pubkey,
-    },
+    Frequency,
     Pass,
 }
 
@@ -73,8 +67,10 @@ impl Rule {
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
         update_rule_state: bool,
+        state_pda: &Pubkey,
     ) -> ProgramResult {
-        let (status, rollup_err) = self.low_level_validate(accounts, payload, update_rule_state);
+        let (status, rollup_err) =
+            self.low_level_validate(accounts, payload, update_rule_state, state_pda);
 
         if status {
             ProgramResult::Ok(())
@@ -88,6 +84,7 @@ impl Rule {
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
         update_rule_state: bool,
+        state_pda: &Pubkey,
     ) -> (bool, ProgramError) {
         match self {
             Rule::All { rules } => {
@@ -95,7 +92,8 @@ impl Rule {
                 let mut last = self.to_error();
                 for rule in rules {
                     last = rule.to_error();
-                    let result = rule.low_level_validate(accounts, payload, update_rule_state);
+                    let result =
+                        rule.low_level_validate(accounts, payload, update_rule_state, state_pda);
                     if !result.0 {
                         return result;
                     }
@@ -107,7 +105,8 @@ impl Rule {
                 let mut last = self.to_error();
                 for rule in rules {
                     last = rule.to_error();
-                    let result = rule.low_level_validate(accounts, payload, update_rule_state);
+                    let result =
+                        rule.low_level_validate(accounts, payload, update_rule_state, state_pda);
                     if result.0 {
                         return result;
                     }
@@ -115,7 +114,8 @@ impl Rule {
                 (false, last)
             }
             Rule::Not { rule } => {
-                let result = rule.low_level_validate(accounts, payload, update_rule_state);
+                let result =
+                    rule.low_level_validate(accounts, payload, update_rule_state, state_pda);
                 (!result.0, result.1)
             }
             Rule::AdditionalSigner { account } => {
@@ -250,122 +250,14 @@ impl Rule {
                     (false, RuleSetError::MissingPayloadValue.into())
                 }
             }
-            Rule::Frequency {
-                freq_name: _,
-                freq_account,
-            } => {
+            Rule::Frequency => {
                 msg!("Validating Frequency");
-                // Get the Frequency Rule `AccountInfo`.
-                let freq_account_info = if let Some(account_info) = accounts.get(freq_account) {
-                    account_info
-                } else {
-                    return (false, RuleSetError::MissingAccount.into());
-                };
-
-                // Grab the current time.
-                let current_time = match solana_program::clock::Clock::get() {
-                    Ok(clock) => clock,
-                    Err(err) => return (false, err),
-                };
-
-                // Deserialize the Frequency Rule account data.
-                let mut freq_account_data =
-                    match FrequencyAccount::from_account_info(freq_account_info) {
-                        Ok(freq_account_data) => freq_account_data,
-                        Err(err) => return (false, err),
-                    };
-
-                // Calculate last time + period.
-                let freq_check = if let Some(val) = freq_account_data
-                    .last_update
-                    .checked_add(freq_account_data.period)
-                {
-                    val
-                } else {
-                    return (false, RuleSetError::NumericalOverflow.into());
-                };
-
-                // Compare current time to last time + period.
-                if current_time.unix_timestamp < freq_check {
-                    return (false, self.to_error());
-                }
-
-                // If requested, update `last_update` time in Frequency rule to current time.
-                if update_rule_state {
-                    freq_account_data.last_update = current_time.unix_timestamp;
-                    // Serialize the Frequency Rule.
-                    match freq_account_data.to_account_data(freq_account_info) {
-                        Ok(_) => (true, self.to_error()),
-                        Err(err) => (false, err),
-                    }
-                } else {
-                    (true, self.to_error())
-                }
+                (false, RuleSetError::NotImplemented.into())
             }
             Rule::Pass => {
                 msg!("Validating Pass");
                 (true, self.to_error())
             }
-        }
-    }
-
-    pub fn assert_rule_pda_derivations(
-        &self,
-        owner: &Pubkey,
-        rule_set_name: &String,
-        accounts: &HashMap<Pubkey, &AccountInfo>,
-    ) -> ProgramResult {
-        match self {
-            Rule::All { rules } => {
-                for rule in rules {
-                    rule.assert_rule_pda_derivations(owner, rule_set_name, accounts)?;
-                }
-                Ok(())
-            }
-            Rule::Any { rules } => {
-                let mut error: Option<ProgramResult> = None;
-                for rule in rules {
-                    match rule.assert_rule_pda_derivations(owner, rule_set_name, accounts) {
-                        Ok(_) => return Ok(()),
-                        Err(e) => error = Some(Err(e)),
-                    }
-                }
-                error.unwrap_or_else(|| Err(RuleSetError::DataTypeMismatch.into()))
-            }
-            Rule::Frequency {
-                freq_name,
-                freq_account,
-            } => {
-                msg!("Assert Frequency PDA deriviation");
-                if let Some(freq_pda_account_info) = accounts.get(freq_account) {
-                    // Frequency PDA account must be owned by this program.
-                    if *freq_pda_account_info.owner != crate::ID {
-                        return Err(RuleSetError::IncorrectOwner.into());
-                    }
-
-                    // Frequency PDA account must not be empty.
-                    if freq_pda_account_info.data_is_empty() {
-                        return Err(RuleSetError::DataIsEmpty.into());
-                    }
-
-                    // Check Frequency account info derivation.
-                    let _bump = assert_derivation(
-                        &crate::ID,
-                        freq_account,
-                        &[
-                            FREQ_PDA.as_bytes(),
-                            owner.as_ref(),
-                            rule_set_name.as_bytes(),
-                            freq_name.as_bytes(),
-                        ],
-                    )?;
-                } else {
-                    return Err(RuleSetError::MissingAccount.into());
-                }
-
-                Ok(())
-            }
-            _ => Ok(()),
         }
     }
 

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -123,6 +123,17 @@ async fn basic_royalty_enforcement() {
 
     context.banks_client.process_transaction(tx).await.unwrap();
 
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Find RuleSet state PDA.
+    let (rule_set_state_addr, _rule_set_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "basic_royalty_enforcement".to_string(),
+            mint,
+        );
+
     // Store the payload of data to validate against the rule definition.
     // In this case the Target will be used to look up the `AccountInfo`
     // and see who the owner is.
@@ -134,6 +145,8 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Transfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Transfer.to_string(),
         payload,
         true,
@@ -192,6 +205,8 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Delegate.to_string(),
         payload.clone(),
         true,
@@ -219,6 +234,8 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `SaleTransfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::SaleTransfer.to_string(),
         payload,
         true,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -144,6 +144,8 @@ async fn basic_royalty_enforcement() {
 
     // Create a `validate` instruction for a `Transfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,
@@ -204,6 +206,8 @@ async fn basic_royalty_enforcement() {
 
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,
@@ -233,6 +237,8 @@ async fn basic_royalty_enforcement() {
     // --------------------------------
     // Create a `validate` instruction for a `SaleTransfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -126,14 +126,6 @@ async fn basic_royalty_enforcement() {
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
-    // Find RuleSet state PDA.
-    let (rule_set_state_addr, _rule_set_bump) =
-        mpl_token_auth_rules::pda::find_rule_set_state_address(
-            context.payer.pubkey(),
-            "basic_royalty_enforcement".to_string(),
-            mint,
-        );
-
     // Store the payload of data to validate against the rule definition.
     // In this case the Target will be used to look up the `AccountInfo`
     // and see who the owner is.
@@ -144,14 +136,14 @@ async fn basic_royalty_enforcement() {
 
     // Create a `validate` instruction for a `Transfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Transfer.to_string(),
         payload,
-        true,
+        false,
         vec![AccountMeta::new_readonly(
             fake_token_metadata_owned_escrow.pubkey(),
             false,
@@ -206,14 +198,14 @@ async fn basic_royalty_enforcement() {
 
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Delegate.to_string(),
         payload.clone(),
-        true,
+        false,
         vec![],
     );
 
@@ -237,14 +229,14 @@ async fn basic_royalty_enforcement() {
     // --------------------------------
     // Create a `validate` instruction for a `SaleTransfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::SaleTransfer.to_string(),
         payload,
-        true,
+        false,
         vec![],
     );
 

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -56,24 +56,16 @@ async fn test_payer_not_signer_fails() {
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
-    // Find RuleSet state PDA.
-    let (rule_set_state_addr, _rule_set_bump) =
-        mpl_token_auth_rules::pda::find_rule_set_state_address(
-            context.payer.pubkey(),
-            "test rule_set".to_string(),
-            mint,
-        );
-
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Transfer.to_string(),
         Payload::default(),
-        true,
+        false,
         vec![],
     );
 
@@ -170,27 +162,19 @@ async fn test_additional_signer_and_amount() {
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
-    // Find RuleSet state PDA.
-    let (rule_set_state_addr, _rule_set_bump) =
-        mpl_token_auth_rules::pda::find_rule_set_state_address(
-            context.payer.pubkey(),
-            "test rule_set".to_string(),
-            mint,
-        );
-
     // Store the payload of data to validate against the rule definition.
     let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(2))]);
 
     // Create a `validate` instruction WITHOUT the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Transfer.to_string(),
         payload.clone(),
-        true,
+        false,
         vec![AccountMeta::new_readonly(context.payer.pubkey(), true)],
     );
 
@@ -223,14 +207,14 @@ async fn test_additional_signer_and_amount() {
 
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Transfer.to_string(),
         payload,
-        true,
+        false,
         vec![
             AccountMeta::new_readonly(context.payer.pubkey(), true),
             AccountMeta::new_readonly(second_signer.pubkey(), true),
@@ -257,14 +241,14 @@ async fn test_additional_signer_and_amount() {
 
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Transfer.to_string(),
         payload,
-        true,
+        false,
         vec![
             AccountMeta::new_readonly(context.payer.pubkey(), true),
             AccountMeta::new_readonly(second_signer.pubkey(), true),
@@ -361,24 +345,16 @@ async fn test_pass() {
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
-    // Find RuleSet state PDA.
-    let (rule_set_state_addr, _rule_set_bump) =
-        mpl_token_auth_rules::pda::find_rule_set_state_address(
-            context.payer.pubkey(),
-            "test rule_set".to_string(),
-            mint,
-        );
-
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
-        context.payer.pubkey(),
-        context.payer.pubkey(),
         rule_set_addr,
-        rule_set_state_addr,
         mint,
+        None,
+        None,
+        None,
         Operation::Transfer.to_string(),
         Payload::default(),
-        true,
+        false,
         vec![],
     );
 

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -53,9 +53,22 @@ async fn test_payer_not_signer_fails() {
         _ => panic!("Unexpected error {:?}", err),
     }
 
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Find RuleSet state PDA.
+    let (rule_set_state_addr, _rule_set_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "test rule_set".to_string(),
+            mint,
+        );
+
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Transfer.to_string(),
         Payload::default(),
         true,
@@ -152,12 +165,25 @@ async fn test_additional_signer_and_amount() {
         .await
         .expect("creation should succeed");
 
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Find RuleSet state PDA.
+    let (rule_set_state_addr, _rule_set_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "test rule_set".to_string(),
+            mint,
+        );
+
     // Store the payload of data to validate against the rule definition.
     let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(2))]);
 
     // Create a `validate` instruction WITHOUT the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Transfer.to_string(),
         payload.clone(),
         true,
@@ -194,6 +220,8 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Transfer.to_string(),
         payload,
         true,
@@ -224,6 +252,8 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Transfer.to_string(),
         payload,
         true,
@@ -259,128 +289,6 @@ async fn test_additional_signer_and_amount() {
         }
         _ => panic!("Unexpected error {:?}", err),
     }
-}
-
-#[tokio::test]
-async fn test_frequency() {
-    let mut context = program_test().start_with_context().await;
-
-    // --------------------------------
-    // Frequency Rule PDA
-    // --------------------------------
-    // Find Frequency Rule PDA.
-    let (freq_account, _freq_account_bump) = mpl_token_auth_rules::pda::find_frequency_pda_address(
-        context.payer.pubkey(),
-        "test rule_set".to_string(),
-        "frequency rule".to_string(),
-    );
-
-    // Create a `create_frequency_rule` instruction.
-    let freq_rule_ix = mpl_token_auth_rules::instruction::create_frequency_rule(
-        context.payer.pubkey(),
-        freq_account,
-        "test rule_set".to_string(),
-        "frequency rule".to_string(),
-        0,
-        10,
-    );
-
-    // Add it to a transaction.
-    let freq_rule_tx = Transaction::new_signed_with_payer(
-        &[freq_rule_ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    // Process the transaction.
-    context
-        .banks_client
-        .process_transaction(freq_rule_tx)
-        .await
-        .expect("creation of frequency PDA should succeed");
-
-    // --------------------------------
-    // Create RuleSet
-    // --------------------------------
-    // Find RuleSet PDA.
-    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
-        context.payer.pubkey(),
-        "test rule_set".to_string(),
-    );
-
-    // Create a Frequency Rule.
-    let freq_rule = Rule::Frequency {
-        freq_name: "frequency rule".to_string(),
-        freq_account,
-    };
-
-    // Create a RuleSet.
-    let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set
-        .add(Operation::Transfer.to_string(), freq_rule)
-        .unwrap();
-
-    println!("{:#?}", rule_set);
-
-    // Serialize the RuleSet using RMP serde.
-    let mut serialized_data = Vec::new();
-    rule_set
-        .serialize(&mut Serializer::new(&mut serialized_data))
-        .unwrap();
-
-    // Create a `create` instruction.
-    let create_ix = mpl_token_auth_rules::instruction::create(
-        context.payer.pubkey(),
-        rule_set_addr,
-        serialized_data,
-        vec![freq_account],
-    );
-
-    // Add it to a transaction.
-    let create_tx = Transaction::new_signed_with_payer(
-        &[create_ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    // Process the transaction.
-    context
-        .banks_client
-        .process_transaction(create_tx)
-        .await
-        .expect("creation should succeed");
-
-    // --------------------------------
-    // Validate Frequency Rule
-    // --------------------------------
-    // Warp some slots before validating.
-    context.warp_to_slot(2).unwrap();
-
-    // Create a `validate` instruction passing in the Frequency Rule account.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        Operation::Transfer.to_string(),
-        Payload::default(),
-        true,
-        vec![AccountMeta::new(freq_account, false)],
-    );
-
-    // Add it to a transaction.
-    let validate_tx = Transaction::new_signed_with_payer(
-        &[validate_ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    // Process the transaction.
-    context
-        .banks_client
-        .process_transaction(validate_tx)
-        .await
-        .expect("validation should succeed");
 }
 
 #[tokio::test]
@@ -442,9 +350,22 @@ async fn test_pass() {
     // Warp some slots before validating.
     context.warp_to_slot(2).unwrap();
 
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Find RuleSet state PDA.
+    let (rule_set_state_addr, _rule_set_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "test rule_set".to_string(),
+            mint,
+        );
+
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
+        rule_set_state_addr,
+        mint,
         Operation::Transfer.to_string(),
         Payload::default(),
         true,

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -66,6 +66,8 @@ async fn test_payer_not_signer_fails() {
 
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,
@@ -181,6 +183,8 @@ async fn test_additional_signer_and_amount() {
 
     // Create a `validate` instruction WITHOUT the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,
@@ -219,6 +223,8 @@ async fn test_additional_signer_and_amount() {
 
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,
@@ -251,6 +257,8 @@ async fn test_additional_signer_and_amount() {
 
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,
@@ -363,6 +371,8 @@ async fn test_pass() {
 
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
+        context.payer.pubkey(),
+        context.payer.pubkey(),
         rule_set_addr,
         rule_set_state_addr,
         mint,


### PR DESCRIPTION
### Discussion item
* Right now this is written such that the Frequency rule would have an authority that must sign if frequency state is updated, and there could be a different rule with a different authority that must sign for that rule.  That seems the most future-flexible to me, but if we wanted to keep it simple we could just have one RuleSet authority at the RuleSet level that must be a signer whenever any state is meant to be updated across any rules.

### UPDATE
* Made `payer`, `rule_authority`, and `rule_set_state_pda` optional accounts.

### Notes
* Add `payer` and `rule_authority` signer accounts to `validate` instruction. 
  * They do not need to be signers if Rule state is not
being updated (bool parameter is false).
  * `payer` covers paying for Rule state storage.
  * `rule_authority` is meant to be a signing PDA from the
calling program to prove that the caller is authorized
to update the Rule state.
* Also added to nonsigner accounts to `validate` instruction: `rule_set_state_pda` and `mint`.
  * Mint is used as a seed for `rule_set_state_pda` PDA to ensure state is tied to the token.
* Remove current `Frequency` rule.
* Add Frequency rule `authority` and check that it's a signer.  If that passes return `NotImplemented`.
* Update tests.