### PR TITLE
use String for HashMap keys

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -19,7 +19,7 @@ pub struct CreateArgs {
 /// Args for `validate` instruction.
 pub struct ValidateArgs {
     /// `Operation` to validate.
-    pub operation: u16,
+    pub operation: String,
     /// `Payload` data used for rule validation.
     pub payload: Payload,
     /// Update any relevant state stored in Rule, such as the Frequency `last_update` time value.
@@ -94,7 +94,7 @@ pub fn create(
 #[allow(clippy::too_many_arguments)]
 pub fn validate(
     rule_set_pda: Pubkey,
-    operation: u16,
+    operation: String,
     payload: Payload,
     update_rule_state: bool,
     additional_rule_accounts: Vec<AccountMeta>,

--- a/program/src/state/rule_set.rs
+++ b/program/src/state/rule_set.rs
@@ -4,13 +4,14 @@ use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct RuleSet {
     /// Name of the RuleSet, used in PDA derivation.
     rule_set_name: String,
     /// Owner (creator) of the RuleSet.
     owner: Pubkey,
     /// A map to determine the `Rule` that belongs to a given `Operation`.
-    pub operations: HashMap<u16, Rule>,
+    pub operations: HashMap<String, Rule>,
 }
 
 impl RuleSet {
@@ -35,7 +36,7 @@ impl RuleSet {
 
     /// Add a key-value pair into a `RuleSet`.  If this key is already in the `RuleSet`
     /// nothing is updated and an error is returned.
-    pub fn add(&mut self, operation: u16, rules: Rule) -> ProgramResult {
+    pub fn add(&mut self, operation: String, rules: Rule) -> ProgramResult {
         if self.operations.get(&operation).is_none() {
             self.operations.insert(operation, rules);
             Ok(())
@@ -44,7 +45,7 @@ impl RuleSet {
         }
     }
 
-    pub fn get(&self, operation: u16) -> Option<&Rule> {
+    pub fn get(&self, operation: String) -> Option<&Rule> {
         self.operations.get(&operation)
     }
 }

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -6,7 +6,6 @@ use mpl_token_auth_rules::{
     payload::{LeafInfo, Payload, PayloadKey, PayloadType},
     state::{Rule, RuleSet},
 };
-use num_traits::ToPrimitive;
 use rmp_serde::Serializer;
 use serde::Serialize;
 use solana_program::instruction::AccountMeta;
@@ -54,20 +53,17 @@ async fn basic_royalty_enforcement() {
         context.payer.pubkey(),
     );
     basic_royalty_enforcement_rule_set
-        .add(
-            Operation::Transfer.to_u16().unwrap(),
-            owned_by_token_metadata,
-        )
+        .add(Operation::Transfer.to_string(), owned_by_token_metadata)
         .unwrap();
     basic_royalty_enforcement_rule_set
         .add(
-            Operation::Delegate.to_u16().unwrap(),
+            Operation::Delegate.to_string(),
             leaf_in_marketplace_tree.clone(),
         )
         .unwrap();
     basic_royalty_enforcement_rule_set
         .add(
-            Operation::SaleTransfer.to_u16().unwrap(),
+            Operation::SaleTransfer.to_string(),
             leaf_in_marketplace_tree,
         )
         .unwrap();
@@ -138,7 +134,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Transfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         payload,
         true,
         vec![AccountMeta::new_readonly(
@@ -196,7 +192,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Delegate.to_u16().unwrap(),
+        Operation::Delegate.to_string(),
         payload.clone(),
         true,
         vec![],
@@ -223,7 +219,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `SaleTransfer` operation.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::SaleTransfer.to_u16().unwrap(),
+        Operation::SaleTransfer.to_string(),
         payload,
         true,
         vec![],

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -8,7 +8,6 @@ use mpl_token_auth_rules::{
     state::{CompareOp, Rule, RuleSet},
 };
 use num_traits::cast::FromPrimitive;
-use num_traits::ToPrimitive;
 use rmp_serde::Serializer;
 use serde::Serialize;
 use solana_program::instruction::{AccountMeta, InstructionError};
@@ -57,7 +56,7 @@ async fn test_payer_not_signer_fails() {
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         Payload::default(),
         true,
         vec![],
@@ -119,7 +118,7 @@ async fn test_additional_signer_and_amount() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_u16().unwrap(), overall_rule)
+        .add(Operation::Transfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -159,7 +158,7 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITHOUT the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         payload.clone(),
         true,
         vec![AccountMeta::new_readonly(context.payer.pubkey(), true)],
@@ -195,7 +194,7 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         payload,
         true,
         vec![
@@ -225,7 +224,7 @@ async fn test_additional_signer_and_amount() {
     // Create a `validate` instruction WITH the second signer.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         payload,
         true,
         vec![
@@ -319,7 +318,7 @@ async fn test_frequency() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_u16().unwrap(), freq_rule)
+        .add(Operation::Transfer.to_string(), freq_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -362,7 +361,7 @@ async fn test_frequency() {
     // Create a `validate` instruction passing in the Frequency Rule account.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         Payload::default(),
         true,
         vec![AccountMeta::new(freq_account, false)],
@@ -403,7 +402,7 @@ async fn test_pass() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_u16().unwrap(), pass_rule)
+        .add(Operation::Transfer.to_string(), pass_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -446,7 +445,7 @@ async fn test_pass() {
     // Create a `validate` instruction.
     let validate_ix = mpl_token_auth_rules::instruction::validate(
         rule_set_addr,
-        Operation::Transfer.to_u16().unwrap(),
+        Operation::Transfer.to_string(),
         Payload::default(),
         true,
         vec![],

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -9,6 +9,16 @@ pub enum Operation {
     SaleTransfer,
 }
 
+impl ToString for Operation {
+    fn to_string(&self) -> String {
+        match self {
+            Operation::Transfer => "Transfer".to_string(),
+            Operation::Delegate => "Delegate".to_string(),
+            Operation::SaleTransfer => "SaleTransfer".to_string(),
+        }
+    }
+}
+
 pub fn program_test() -> ProgramTest {
     ProgramTest::new("mpl_token_auth_rules", mpl_token_auth_rules::id(), None)
 }


### PR DESCRIPTION
Using Message Pack encoding, JSON objects do not deserialize correctly into a Rust `HashMap` type where the key is anything other than a `String`. This PR changes the `operation` type from `u16` to a `String` to allow proper deserialization of JavaScript-created rule sets.

It also ensures that all `RuleSet` fields are decoded correctly from `CamelCase` naming.