### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/install-linux-build-deps/action.yml
+++ b/.github/actions/install-linux-build-deps/action.yml
@@ -9,11 +9,11 @@ runs:
         sudo apt-get update
       shell: bash
 
-    - name: apt-get install clang 
-      run: |
-        sudo apt-get install -y clang-7 --allow-unauthenticated
-        clang-7 --version
-      shell: bash
+    # - name: apt-get install clang 
+    #   run: |
+    #     sudo apt-get install -y clang-7 --allow-unauthenticated
+    #     clang-7 --version
+    #   shell: bash
       
     - name: apt-get install ssl libs
       run: |

--- a/.github/actions/yarn-install-and-build/action.yml
+++ b/.github/actions/yarn-install-and-build/action.yml
@@ -23,7 +23,7 @@ runs:
         yarn install
         echo 'Build SDK: yarn build'
         yarn build
-      working-directory: ./js
+      working-directory: packages/sdk
       shell: bash
 
     - name: Install modules

--- a/.github/actions/yarn-install-and-verify/action.yml
+++ b/.github/actions/yarn-install-and-verify/action.yml
@@ -27,7 +27,7 @@ runs:
         yarn install
         echo 'Build SDK: yarn build'
         yarn build
-      working-directory: ./js
+      working-directory: packages/sdk
       shell: bash
 
     ##############

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,24 +5,6 @@ on:
   pull_request:
 
 name: Rust Checks
-
-jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - run: sudo apt install libudev-dev
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path program/Cargo.toml
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
 
 name: Rust Checks
+
+jobs:
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/program-test.yml
+++ b/.github/workflows/program-test.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-and-test-program:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2204
     env:
       cache_id: program-test
 

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: ./.github/actions/yarn-install-and-verify
         with: 
           cache_id: sdk
-          working_dir: ./js
+          working_dir: packages/sdk
           skip_test: true


### PR DESCRIPTION
`cargo check` is a subset of `cargo clippy` IIRC as `clippy` also runs `check` so the ci.yml file can just be `cargo fmt` and `cargo clippy` and maybe `cargo test` if you have normal Rust unit or integration tests.

I removed the clang-7 dependency as it's not needed and that looks like it fixed the program tests.