### PR TITLE
Danenbm/versioning

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -107,6 +107,10 @@ pub enum RuleSetError {
     /// 24 - Rule authority is not signer
     #[error("Rule authority is not signer")]
     RuleAuthorityIsNotSigner,
+
+    /// 25 - Unsupported RuleSet version
+    #[error("Unsupported RuleSet version")]
+    UnsupportedRuleSetVersion,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -9,21 +9,26 @@ use solana_program::{
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Args for `create` instruction.
-pub struct CreateArgs {
-    /// RuleSet pre-serialized by caller into the MessagePack format.
-    pub serialized_rule_set: Vec<u8>,
+pub enum CreateArgs {
+    V1 {
+        /// RuleSet pre-serialized by caller into the MessagePack format.
+        serialized_rule_set: Vec<u8>,
+    },
 }
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Args for `validate` instruction.
-pub struct ValidateArgs {
-    /// `Operation` to validate.
-    pub operation: String,
-    /// `Payload` data used for rule validation.
-    pub payload: Payload,
-    /// Update any relevant state stored in Rule, such as the Frequency `last_update` time value.
-    pub update_rule_state: bool,
+
+pub enum ValidateArgs {
+    V1 {
+        /// `Operation` to validate.
+        operation: String,
+        /// `Payload` data used for rule validation.
+        payload: Payload,
+        /// Update any relevant state stored in Rule, such as the Frequency `last_update` time value.
+        update_rule_state: bool,
+    },
 }
 
 #[derive(Debug, Clone, ShankInstruction, BorshSerialize, BorshDeserialize)]
@@ -70,7 +75,7 @@ pub fn create(
     Instruction {
         program_id: crate::ID,
         accounts,
-        data: RuleSetInstruction::Create(CreateArgs {
+        data: RuleSetInstruction::Create(CreateArgs::V1 {
             serialized_rule_set,
         })
         .try_to_vec()
@@ -114,7 +119,7 @@ pub fn validate(
     Instruction {
         program_id: crate::ID,
         accounts,
-        data: RuleSetInstruction::Validate(ValidateArgs {
+        data: RuleSetInstruction::Validate(ValidateArgs::V1 {
             operation,
             payload,
             update_rule_state,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     error::RuleSetError,
-    instruction::RuleSetInstruction,
+    instruction::{CreateArgs, RuleSetInstruction, ValidateArgs},
     pda::{PREFIX, STATE_PDA},
     state::RuleSet,
     utils::{assert_derivation, create_or_allocate_account_raw},
@@ -28,174 +28,211 @@ impl Processor {
         let instruction = RuleSetInstruction::try_from_slice(instruction_data)?;
         match instruction {
             RuleSetInstruction::Create(args) => {
-                let account_info_iter = &mut accounts.iter();
-
-                // Required accounts.
-                let payer_info = next_account_info(account_info_iter)?;
-                let rule_set_pda_info = next_account_info(account_info_iter)?;
-                let system_program_info = next_account_info(account_info_iter)?;
-
-                if !payer_info.is_signer {
-                    return Err(RuleSetError::PayerIsNotSigner.into());
-                }
-
-                // Deserialize RuleSet.
-                let rule_set: RuleSet = rmp_serde::from_slice(&args.serialized_rule_set)
-                    .map_err(|_| RuleSetError::MessagePackDeserializationError)?;
-
-                if rule_set.name().len() > MAX_NAME_LENGTH {
-                    return Err(RuleSetError::NameTooLong.into());
-                }
-
-                // The payer/signer must be the RuleSet owner.
-                if payer_info.key != rule_set.owner() {
-                    return Err(RuleSetError::RuleSetOwnerMismatch.into());
-                }
-
-                // Check RuleSet account info derivation.
-                let bump = assert_derivation(
-                    program_id,
-                    rule_set_pda_info.key,
-                    &[
-                        PREFIX.as_bytes(),
-                        payer_info.key.as_ref(),
-                        rule_set.name().as_bytes(),
-                    ],
-                )?;
-
-                let rule_set_seeds = &[
-                    PREFIX.as_ref(),
-                    payer_info.key.as_ref(),
-                    rule_set.name().as_ref(),
-                    &[bump],
-                ];
-
-                // Create or allocate RuleSet PDA account.
-                create_or_allocate_account_raw(
-                    *program_id,
-                    rule_set_pda_info,
-                    system_program_info,
-                    payer_info,
-                    args.serialized_rule_set.len(),
-                    rule_set_seeds,
-                )?;
-
-                // Copy user-pre-serialized RuleSet to PDA account.
-                sol_memcpy(
-                    &mut rule_set_pda_info.try_borrow_mut_data().unwrap(),
-                    &args.serialized_rule_set,
-                    args.serialized_rule_set.len(),
-                );
-
-                Ok(())
+                msg!("Instruction: Create");
+                create(program_id, accounts, args)
             }
             RuleSetInstruction::Validate(args) => {
-                let account_info_iter = &mut accounts.iter();
-
-                // Required accounts.
-                let rule_set_pda_info = next_account_info(account_info_iter)?;
-                let mint_info = next_account_info(account_info_iter)?;
-                let _system_program_info = next_account_info(account_info_iter)?;
-
-                // Optional accounts are required if we are updating any Rule state.  Note that
-                // `rule_authority_info is marked as unused here but this account is included below
-                // in the `accounts_map` that is passed to Rule `validate`.
-                let (payer_info, _rule_authority_info, rule_set_state_pda_info) =
-                    if args.update_rule_state {
-                        (
-                            Some(next_account_info(account_info_iter)?),
-                            Some(next_account_info(account_info_iter)?),
-                            Some(next_account_info(account_info_iter)?),
-                        )
-                    } else {
-                        (None, None, None)
-                    };
-
-                if args.update_rule_state {
-                    if let Some(payer_info) = payer_info {
-                        if !payer_info.is_signer {
-                            return Err(RuleSetError::PayerIsNotSigner.into());
-                        }
-                    } else {
-                        return Err(ProgramError::NotEnoughAccountKeys);
-                    }
-                }
-
-                // RuleSet must be owned by this program.
-                if *rule_set_pda_info.owner != crate::ID {
-                    return Err(RuleSetError::IncorrectOwner.into());
-                }
-
-                // RuleSet must not be empty.
-                if rule_set_pda_info.data_is_empty() {
-                    return Err(RuleSetError::DataIsEmpty.into());
-                }
-
-                // Borrow the RuleSet PDA data.
-                let data = rule_set_pda_info
-                    .data
-                    .try_borrow()
-                    .map_err(|_| RuleSetError::DataTypeMismatch)?;
-
-                // Deserialize RuleSet.
-                let rule_set: RuleSet = rmp_serde::from_slice(&data)
-                    .map_err(|_| RuleSetError::MessagePackDeserializationError)?;
-
-                // Check RuleSet account info derivation.
-                let _bump = assert_derivation(
-                    program_id,
-                    rule_set_pda_info.key,
-                    &[
-                        PREFIX.as_bytes(),
-                        rule_set.owner().as_ref(),
-                        rule_set.name().as_bytes(),
-                    ],
-                )?;
-
-                // If RuleSet state is to be updated, check account info derivation.
-                if args.update_rule_state {
-                    if let Some(rule_set_state_pda_info) = rule_set_state_pda_info {
-                        let _bump = assert_derivation(
-                            program_id,
-                            rule_set_state_pda_info.key,
-                            &[
-                                STATE_PDA.as_bytes(),
-                                rule_set.owner().as_ref(),
-                                rule_set.name().as_bytes(),
-                                mint_info.key.as_ref(),
-                            ],
-                        )?;
-                    } else {
-                        return Err(ProgramError::NotEnoughAccountKeys);
-                    }
-                }
-
-                // Convert the accounts into a map of `Pubkey`s to the corresponding account infos.
-                // This makes it easy to pass the account infos into validation functions since
-                // they store the `Pubkey`s.
-                let accounts_map = accounts
-                    .iter()
-                    .map(|account| (*account.key, account))
-                    .collect::<HashMap<Pubkey, &AccountInfo>>();
-
-                // Get the Rule from the RuleSet based on the caller-specified operation.
-                let rule = rule_set
-                    .get(args.operation)
-                    .ok_or(RuleSetError::OperationNotFound)?;
-
-                // Validate the Rule.
-                if let Err(err) = rule.validate(
-                    &accounts_map,
-                    &args.payload,
-                    args.update_rule_state,
-                    rule_set_state_pda_info.map(|account_info| account_info.key),
-                ) {
-                    msg!("Failed to validate: {}", err);
-                    return Err(err);
-                }
-
-                Ok(())
+                msg!("Instruction: Validate");
+                validate(program_id, accounts, args)
             }
         }
     }
+}
+
+// Function to match on `CreateArgs` version and call correct implementation.
+fn create(program_id: &Pubkey, accounts: &[AccountInfo], args: CreateArgs) -> ProgramResult {
+    match args {
+        CreateArgs::V1 { .. } => create_v1(program_id, accounts, args),
+    }
+}
+
+/// V1 implementation of the `create` instruction.
+fn create_v1(program_id: &Pubkey, accounts: &[AccountInfo], args: CreateArgs) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Required accounts.
+    let payer_info = next_account_info(account_info_iter)?;
+    let rule_set_pda_info = next_account_info(account_info_iter)?;
+    let system_program_info = next_account_info(account_info_iter)?;
+
+    // Get the V1 arguments for the instruction.
+    let CreateArgs::V1 {
+        serialized_rule_set,
+    } = args;
+
+    if !payer_info.is_signer {
+        return Err(RuleSetError::PayerIsNotSigner.into());
+    }
+
+    // Deserialize RuleSet.
+    let rule_set: RuleSet = rmp_serde::from_slice(&serialized_rule_set)
+        .map_err(|_| RuleSetError::MessagePackDeserializationError)?;
+
+    if rule_set.name().len() > MAX_NAME_LENGTH {
+        return Err(RuleSetError::NameTooLong.into());
+    }
+
+    // The payer/signer must be the RuleSet owner.
+    if payer_info.key != rule_set.owner() {
+        return Err(RuleSetError::RuleSetOwnerMismatch.into());
+    }
+
+    // Check RuleSet account info derivation.
+    let bump = assert_derivation(
+        program_id,
+        rule_set_pda_info.key,
+        &[
+            PREFIX.as_bytes(),
+            payer_info.key.as_ref(),
+            rule_set.name().as_bytes(),
+        ],
+    )?;
+
+    let rule_set_seeds = &[
+        PREFIX.as_ref(),
+        payer_info.key.as_ref(),
+        rule_set.name().as_ref(),
+        &[bump],
+    ];
+
+    // Create or allocate RuleSet PDA account.
+    create_or_allocate_account_raw(
+        *program_id,
+        rule_set_pda_info,
+        system_program_info,
+        payer_info,
+        serialized_rule_set.len(),
+        rule_set_seeds,
+    )?;
+
+    // Copy user-pre-serialized RuleSet to PDA account.
+    sol_memcpy(
+        &mut rule_set_pda_info.try_borrow_mut_data().unwrap(),
+        &serialized_rule_set,
+        serialized_rule_set.len(),
+    );
+
+    Ok(())
+}
+
+// Function to match on `ValidateArgs` version and call correct implementation.
+fn validate(program_id: &Pubkey, accounts: &[AccountInfo], args: ValidateArgs) -> ProgramResult {
+    match args {
+        ValidateArgs::V1 { .. } => validate_v1(program_id, accounts, args),
+    }
+}
+
+/// V1 implementation of the `validate` instruction.
+fn validate_v1(program_id: &Pubkey, accounts: &[AccountInfo], args: ValidateArgs) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Required accounts.
+    let rule_set_pda_info = next_account_info(account_info_iter)?;
+    let mint_info = next_account_info(account_info_iter)?;
+    let _system_program_info = next_account_info(account_info_iter)?;
+
+    // Get the V1 arguments for the instruction.
+    let ValidateArgs::V1 {
+        operation,
+        payload,
+        update_rule_state,
+    } = args;
+
+    // Optional accounts are required if we are updating any Rule state.  Note that
+    // `rule_authority_info is marked as unused here but this account is included below
+    // in the `accounts_map` that is passed to Rule `validate`.
+    let (payer_info, _rule_authority_info, rule_set_state_pda_info) = if update_rule_state {
+        (
+            Some(next_account_info(account_info_iter)?),
+            Some(next_account_info(account_info_iter)?),
+            Some(next_account_info(account_info_iter)?),
+        )
+    } else {
+        (None, None, None)
+    };
+
+    if update_rule_state {
+        if let Some(payer_info) = payer_info {
+            if !payer_info.is_signer {
+                return Err(RuleSetError::PayerIsNotSigner.into());
+            }
+        } else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+    }
+
+    // RuleSet must be owned by this program.
+    if *rule_set_pda_info.owner != crate::ID {
+        return Err(RuleSetError::IncorrectOwner.into());
+    }
+
+    // RuleSet must not be empty.
+    if rule_set_pda_info.data_is_empty() {
+        return Err(RuleSetError::DataIsEmpty.into());
+    }
+
+    // Borrow the RuleSet PDA data.
+    let data = rule_set_pda_info
+        .data
+        .try_borrow()
+        .map_err(|_| RuleSetError::DataTypeMismatch)?;
+
+    // Deserialize RuleSet.
+    let rule_set: RuleSet =
+        rmp_serde::from_slice(&data).map_err(|_| RuleSetError::MessagePackDeserializationError)?;
+
+    // Check RuleSet account info derivation.
+    let _bump = assert_derivation(
+        program_id,
+        rule_set_pda_info.key,
+        &[
+            PREFIX.as_bytes(),
+            rule_set.owner().as_ref(),
+            rule_set.name().as_bytes(),
+        ],
+    )?;
+
+    // If RuleSet state is to be updated, check account info derivation.
+    if update_rule_state {
+        if let Some(rule_set_state_pda_info) = rule_set_state_pda_info {
+            let _bump = assert_derivation(
+                program_id,
+                rule_set_state_pda_info.key,
+                &[
+                    STATE_PDA.as_bytes(),
+                    rule_set.owner().as_ref(),
+                    rule_set.name().as_bytes(),
+                    mint_info.key.as_ref(),
+                ],
+            )?;
+        } else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+    }
+
+    // Convert the accounts into a map of `Pubkey`s to the corresponding account infos.
+    // This makes it easy to pass the account infos into validation functions since
+    // they store the `Pubkey`s.
+    let accounts_map = accounts
+        .iter()
+        .map(|account| (*account.key, account))
+        .collect::<HashMap<Pubkey, &AccountInfo>>();
+
+    // Get the Rule from the RuleSet based on the caller-specified operation.
+    let rule = rule_set
+        .get(operation)
+        .ok_or(RuleSetError::OperationNotFound)?;
+
+    // Validate the Rule.
+    if let Err(err) = rule.validate(
+        &accounts_map,
+        &payload,
+        update_rule_state,
+        rule_set_state_pda_info.map(|account_info| account_info.key),
+    ) {
+        msg!("Failed to validate: {}", err);
+        return Err(err);
+    }
+
+    Ok(())
 }

--- a/program/src/state/rule_set.rs
+++ b/program/src/state/rule_set.rs
@@ -3,9 +3,14 @@ use serde::{Deserialize, Serialize};
 use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
 use std::collections::HashMap;
 
+pub const RULE_SET_VERSION: u32 = 1;
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RuleSet {
+    /// Version of the RuleSet.  This is not a user version, but the version
+    /// of this lib, to be used for future backwards compatibility.
+    version: u32,
     /// Name of the RuleSet, used in PDA derivation.
     rule_set_name: String,
     /// Owner (creator) of the RuleSet.
@@ -18,6 +23,7 @@ impl RuleSet {
     /// Create a new empty `RuleSet`.
     pub fn new(rule_set_name: String, owner: Pubkey) -> Self {
         Self {
+            version: RULE_SET_VERSION,
             rule_set_name,
             owner,
             operations: HashMap::new(),
@@ -27,6 +33,11 @@ impl RuleSet {
     /// Get the name of the `RuleSet`.
     pub fn name(&self) -> &str {
         &self.rule_set_name
+    }
+
+    /// Get the version of the `RuleSet`.
+    pub fn version(&self) -> u32 {
+        self.version
     }
 
     /// Get the owner of the `RuleSet`.


### PR DESCRIPTION
### Notes
* Convert args to enums with version.
* Also separate processor functions based on arg version.
* Add version field to RuleSet

### Discussion
I think this covers everything:
* If there was a new version of a `RuleSet`, we would be able to detect an old `RuleSet` by using the `RuleSet` version.
* If there was a new version of a `Payload` or any other `CreateArgs` or `ValidateArgs`, if someone used an old instruction builder, we will identify the V1 enum afaik.