### PR TITLE
Using token-metadata context derive proc macro

### DIFF
--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -156,9 +156,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -168,9 +168,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -218,9 +218,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -229,9 +229,9 @@ version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -353,8 +353,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "regex",
  "rustc-hash",
  "shlex",
@@ -454,8 +454,8 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.37",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -464,9 +464,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -475,9 +475,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -553,9 +553,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -939,10 +939,10 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "strsim 0.10.0",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -952,8 +952,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
- "quote 1.0.18",
- "syn 1.0.91",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1009,10 +1009,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "rustc_version 0.4.0",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1097,9 +1097,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1167,9 +1167,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07b7cc9cd8c08d10db74fca3b20949b9b6199725c04a0cce6d543496098fcac"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1208,9 +1208,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1221,10 +1221,10 @@ checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "rustc_version 0.4.0",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1234,9 +1234,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1463,9 +1463,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2063,9 +2063,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2434,9 +2434,9 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2446,6 +2446,7 @@ dependencies = [
  "assert_matches",
  "borsh",
  "mpl-token-metadata",
+ "mpl-token-metadata-context-derive",
  "num-derive",
  "num-traits",
  "rmp-serde",
@@ -2478,6 +2479,15 @@ dependencies = [
  "spl-associated-token-account",
  "spl-token",
  "thiserror",
+]
+
+[[package]]
+name = "mpl-token-metadata-context-derive"
+version = "0.0.1"
+source = "git+https://github.com/metaplex-foundation/metaplex-program-library.git?rev=57723451#5772345137fe92373c435ac22ca96f2a4b519bea"
+dependencies = [
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2613,9 +2623,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2686,9 +2696,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2812,9 +2822,9 @@ checksum = "ed9a247206016d424fe8497bc611e510887af5c261fbbf977877c4bb55ca4d82"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2966,9 +2976,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3007,9 +3017,9 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3071,8 +3081,8 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
 dependencies = [
- "proc-macro2 1.0.37",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3101,9 +3111,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -3113,8 +3123,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "version_check",
 ]
 
@@ -3135,11 +3145,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3212,9 +3222,9 @@ checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3225,9 +3235,9 @@ checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3324,11 +3334,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.49",
 ]
 
 [[package]]
@@ -3794,9 +3804,9 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3865,9 +3875,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
@@ -3883,13 +3893,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3932,9 +3942,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4061,10 +4071,10 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "shank_macro_impl",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4074,10 +4084,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "serde",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4622,10 +4632,10 @@ version = "1.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1427b307e619e53e33987967112b0bc5ae2983915e00a46720b589bffe7f924b"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "rustc_version 0.4.0",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5194,10 +5204,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df36a10a657b35accd2fd7ae097e9426cbbdbf8219a79e8a7d3be7b500be0e7e"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "rustversion",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5663,11 +5673,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "serde",
  "serde_derive",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5677,13 +5687,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5731,10 +5741,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "rustversion",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5762,13 +5772,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "unicode-xid 0.2.2",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5783,9 +5793,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "unicode-xid 0.2.2",
 ]
 
@@ -5853,9 +5863,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5915,9 +5925,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6010,10 +6020,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
  "standback",
- "syn 1.0.91",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6086,9 +6096,9 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6277,10 +6287,10 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.49",
  "prost-build 0.9.0",
- "quote 1.0.18",
- "syn 1.0.91",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6290,10 +6300,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d17087af5c80e5d5fc8ba9878e60258065a0a757e35efe7a05b7904bece1943"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.49",
  "prost-build 0.10.1",
- "quote 1.0.18",
- "syn 1.0.91",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6366,9 +6376,9 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6474,6 +6484,12 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -6673,9 +6689,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -6697,7 +6713,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
- "quote 1.0.18",
+ "quote 1.0.23",
  "wasm-bindgen-macro-support",
 ]
 
@@ -6707,9 +6723,9 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6968,9 +6984,9 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,13 @@ keywords = ["nft", "metaplex", "solana", "blockchain"]
 solana-program = "=1.13.5"
 shank = "0.0.11"
 borsh = "0.9.3"
-thiserror = "~1.0"
+thiserror = "1.0"
 num-derive = "0.3.3"
-num-traits = "~0.2"
-serde = { version = "1.0.136", features = ["derive"]}
+num-traits = "0.2"
+serde = { version = "1.0.149", features = ["derive"]}
 serde_with = { version = "1.12.0", optional = true }
 rmp-serde = "1.1.1"
+mpl-token-metadata-context-derive = { git = "https://github.com/metaplex-foundation/metaplex-program-library.git", rev = "57723451" }
 
 [features]
 no-entrypoint = []

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -10,9 +10,9 @@ use solana_program::{
 use crate::{error::RuleSetError, processor::Processor};
 
 entrypoint!(process_instruction);
-fn process_instruction(
+fn process_instruction<'a>(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &'a [AccountInfo<'a>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     if let Err(error) = Processor::process_instruction(program_id, accounts, instruction_data) {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -93,15 +93,18 @@ impl InstructionBuilder for builders::Validate {
         ];
 
         if let Some(payer) = self.payer {
-            accounts.push(AccountMeta::new(payer, true));
+            let is_signer = payer != crate::ID;
+            accounts.push(AccountMeta::new(payer, is_signer));
         }
 
         if let Some(rule_authority) = self.rule_authority {
-            accounts.push(AccountMeta::new_readonly(rule_authority, true));
+            let is_signer = rule_authority != crate::ID;
+            accounts.push(AccountMeta::new_readonly(rule_authority, is_signer));
         }
 
         if let Some(rule_set_state_pda) = self.rule_set_state_pda {
-            accounts.push(AccountMeta::new(rule_set_state_pda, false));
+            let is_signer = rule_set_state_pda != crate::ID;
+            accounts.push(AccountMeta::new(rule_set_state_pda, is_signer));
         }
 
         accounts.extend(self.additional_rule_accounts.clone());

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -92,19 +92,25 @@ impl InstructionBuilder for builders::Validate {
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
         ];
 
+        // Add optional account or `crate::ID`.
         if let Some(payer) = self.payer {
-            let is_signer = payer != crate::ID;
-            accounts.push(AccountMeta::new(payer, is_signer));
+            accounts.push(AccountMeta::new(payer, true));
+        } else {
+            accounts.push(AccountMeta::new_readonly(crate::ID, false));
         }
 
+        // Add optional account or `crate::ID`.
         if let Some(rule_authority) = self.rule_authority {
-            let is_signer = rule_authority != crate::ID;
-            accounts.push(AccountMeta::new_readonly(rule_authority, is_signer));
+            accounts.push(AccountMeta::new_readonly(rule_authority, true));
+        } else {
+            accounts.push(AccountMeta::new_readonly(crate::ID, false));
         }
 
+        // Add optional account or `crate::ID`.
         if let Some(rule_set_state_pda) = self.rule_set_state_pda {
-            let is_signer = rule_set_state_pda != crate::ID;
-            accounts.push(AccountMeta::new(rule_set_state_pda, is_signer));
+            accounts.push(AccountMeta::new(rule_set_state_pda, true));
+        } else {
+            accounts.push(AccountMeta::new_readonly(crate::ID, false));
         }
 
         accounts.extend(self.additional_rule_accounts.clone());

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,7 +1,9 @@
 use crate::payload::Payload;
 use borsh::{BorshDeserialize, BorshSerialize};
+use mpl_token_metadata_context_derive::AccountContext;
 use shank::ShankInstruction;
 use solana_program::{
+    account_info::AccountInfo,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
 };
@@ -31,7 +33,7 @@ pub enum ValidateArgs {
     },
 }
 
-#[derive(Debug, Clone, ShankInstruction, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, ShankInstruction, AccountContext, BorshSerialize, BorshDeserialize)]
 #[rustfmt::skip]
 /// Instructions available in this program.
 pub enum RuleSetInstruction {
@@ -39,6 +41,8 @@ pub enum RuleSetInstruction {
     #[account(0, signer, writable, name="payer", desc="Payer and creator of the RuleSet")]
     #[account(1, writable, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
+    #[args(serialized_rule_set: Vec<u8>)]
+    #[args(additional_rule_accounts: Vec<Pubkey>)]
     Create(CreateArgs),
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by calling the
@@ -53,78 +57,74 @@ pub enum RuleSetInstruction {
     #[account(3, optional, signer, writable, name="payer", desc="Payer for RuleSet state PDA account")]
     #[account(4, optional, signer, name="rule_authority", desc="Signing authority for any Rule state updates")]
     #[account(5, optional, writable, name="rule_set_state_pda", desc = "The PDA account where any RuleSet state is stored")]
+    #[args(operation: String)]
+    #[args(payload: Payload)]
+    #[args(update_rule_state: bool)]
+    #[args(additional_rule_accounts: Vec<AccountMeta>)]
     Validate(ValidateArgs),
 }
+
 /// Builds a `create` instruction.
-pub fn create(
-    payer: Pubkey,
-    rule_set_pda: Pubkey,
-    serialized_rule_set: Vec<u8>,
-    additional_rule_accounts: Vec<Pubkey>,
-) -> Instruction {
-    let mut accounts = vec![
-        AccountMeta::new(payer, true),
-        AccountMeta::new(rule_set_pda, false),
-        AccountMeta::new_readonly(solana_program::system_program::id(), false),
-    ];
+impl InstructionBuilder for builders::Create {
+    fn instruction(&self) -> solana_program::instruction::Instruction {
+        let mut accounts = vec![
+            AccountMeta::new(self.payer, true),
+            AccountMeta::new(self.rule_set_pda, false),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        ];
 
-    for account in additional_rule_accounts {
-        accounts.push(AccountMeta::new_readonly(account, false));
-    }
+        for account in self.additional_rule_accounts.iter() {
+            accounts.push(AccountMeta::new_readonly(*account, false));
+        }
 
-    Instruction {
-        program_id: crate::ID,
-        accounts,
-        data: RuleSetInstruction::Create(CreateArgs::V1 {
-            serialized_rule_set,
-        })
-        .try_to_vec()
-        .unwrap(),
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data: RuleSetInstruction::Create(self.args.clone())
+                .try_to_vec()
+                .unwrap(),
+        }
     }
 }
 
 /// Builds a `validate` instruction.
-#[allow(clippy::too_many_arguments)]
-pub fn validate(
-    rule_set_pda: Pubkey,
-    mint: Pubkey,
-    payer: Option<Pubkey>,
-    rule_authority: Option<Pubkey>,
-    rule_set_state_pda: Option<Pubkey>,
-    operation: String,
-    payload: Payload,
-    update_rule_state: bool,
-    additional_rule_accounts: Vec<AccountMeta>,
-) -> Instruction {
-    let mut accounts = vec![
-        AccountMeta::new_readonly(rule_set_pda, false),
-        AccountMeta::new_readonly(mint, false),
-        AccountMeta::new_readonly(solana_program::system_program::id(), false),
-    ];
+impl InstructionBuilder for builders::Validate {
+    fn instruction(&self) -> solana_program::instruction::Instruction {
+        let mut accounts = vec![
+            AccountMeta::new_readonly(self.rule_set_pda, false),
+            AccountMeta::new_readonly(self.mint, false),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        ];
 
-    if let Some(payer) = payer {
-        accounts.push(AccountMeta::new(payer, true));
+        if let Some(payer) = self.payer {
+            accounts.push(AccountMeta::new(payer, true));
+        }
+
+        if let Some(rule_authority) = self.rule_authority {
+            accounts.push(AccountMeta::new_readonly(rule_authority, true));
+        }
+
+        if let Some(rule_set_state_pda) = self.rule_set_state_pda {
+            accounts.push(AccountMeta::new(rule_set_state_pda, false));
+        }
+
+        accounts.extend(self.additional_rule_accounts.clone());
+
+        Instruction {
+            program_id: crate::ID,
+            accounts,
+            data: RuleSetInstruction::Validate(self.args.clone())
+                .try_to_vec()
+                .unwrap(),
+        }
     }
+}
 
-    if let Some(rule_authority) = rule_authority {
-        accounts.push(AccountMeta::new_readonly(rule_authority, true));
-    }
+pub struct Context<'a, T> {
+    pub accounts: T,
+    pub remaining_accounts: Vec<&'a AccountInfo<'a>>,
+}
 
-    if let Some(rule_set_state_pda) = rule_set_state_pda {
-        accounts.push(AccountMeta::new(rule_set_state_pda, false));
-    }
-
-    accounts.extend(additional_rule_accounts);
-
-    Instruction {
-        program_id: crate::ID,
-        accounts,
-        data: RuleSetInstruction::Validate(ValidateArgs::V1 {
-            operation,
-            payload,
-            update_rule_state,
-        })
-        .try_to_vec()
-        .unwrap(),
-    }
+pub trait InstructionBuilder {
+    fn instruction(&self) -> solana_program::instruction::Instruction;
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -41,7 +41,6 @@ pub enum RuleSetInstruction {
     #[account(0, signer, writable, name="payer", desc="Payer and creator of the RuleSet")]
     #[account(1, writable, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
-    #[args(serialized_rule_set: Vec<u8>)]
     #[args(additional_rule_accounts: Vec<Pubkey>)]
     Create(CreateArgs),
 
@@ -57,9 +56,6 @@ pub enum RuleSetInstruction {
     #[account(3, optional, signer, writable, name="payer", desc="Payer for RuleSet state PDA account")]
     #[account(4, optional, signer, name="rule_authority", desc="Signing authority for any Rule state updates")]
     #[account(5, optional, writable, name="rule_set_state_pda", desc = "The PDA account where any RuleSet state is stored")]
-    #[args(operation: String)]
-    #[args(payload: Payload)]
-    #[args(update_rule_state: bool)]
     #[args(additional_rule_accounts: Vec<AccountMeta>)]
     Validate(ValidateArgs),
 }

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -69,10 +69,16 @@ impl Rule {
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
         update_rule_state: bool,
-        state_pda: Option<&Pubkey>,
+        rule_set_state_pda: &Option<&AccountInfo>,
+        rule_authority: &Option<&AccountInfo>,
     ) -> ProgramResult {
-        let (status, rollup_err) =
-            self.low_level_validate(accounts, payload, update_rule_state, state_pda);
+        let (status, rollup_err) = self.low_level_validate(
+            accounts,
+            payload,
+            update_rule_state,
+            rule_set_state_pda,
+            rule_authority,
+        );
 
         if status {
             ProgramResult::Ok(())
@@ -86,7 +92,8 @@ impl Rule {
         accounts: &HashMap<Pubkey, &AccountInfo>,
         payload: &Payload,
         _update_rule_state: bool,
-        _state_pda: Option<&Pubkey>,
+        _rule_set_state_pda: &Option<&AccountInfo>,
+        _rule_authority: &Option<&AccountInfo>,
     ) -> (bool, ProgramError) {
         match self {
             Rule::All { rules } => {
@@ -94,8 +101,13 @@ impl Rule {
                 let mut last = self.to_error();
                 for rule in rules {
                     last = rule.to_error();
-                    let result =
-                        rule.low_level_validate(accounts, payload, _update_rule_state, _state_pda);
+                    let result = rule.low_level_validate(
+                        accounts,
+                        payload,
+                        _update_rule_state,
+                        _rule_set_state_pda,
+                        _rule_authority,
+                    );
                     if !result.0 {
                         return result;
                     }
@@ -107,8 +119,13 @@ impl Rule {
                 let mut last = self.to_error();
                 for rule in rules {
                     last = rule.to_error();
-                    let result =
-                        rule.low_level_validate(accounts, payload, _update_rule_state, _state_pda);
+                    let result = rule.low_level_validate(
+                        accounts,
+                        payload,
+                        _update_rule_state,
+                        _rule_set_state_pda,
+                        _rule_authority,
+                    );
                     if result.0 {
                         return result;
                     }
@@ -116,8 +133,13 @@ impl Rule {
                 (false, last)
             }
             Rule::Not { rule } => {
-                let result =
-                    rule.low_level_validate(accounts, payload, _update_rule_state, _state_pda);
+                let result = rule.low_level_validate(
+                    accounts,
+                    payload,
+                    _update_rule_state,
+                    _rule_set_state_pda,
+                    _rule_authority,
+                );
                 (!result.0, result.1)
             }
             Rule::AdditionalSigner { account } => {

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -9,7 +9,6 @@ use mpl_token_auth_rules::{
     },
     payload::{LeafInfo, Payload, PayloadKey, PayloadType},
     state::{Rule, RuleSet},
-    ID,
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
@@ -144,9 +143,6 @@ async fn basic_royalty_enforcement() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::Transfer.to_string(),
@@ -206,9 +202,6 @@ async fn basic_royalty_enforcement() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::Delegate.to_string(),
@@ -240,9 +233,6 @@ async fn basic_royalty_enforcement() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::SaleTransfer.to_string(),

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -14,7 +14,8 @@ use rmp_serde::Serializer;
 use serde::Serialize;
 use solana_program_test::tokio;
 use solana_sdk::{
-    signature::Signer, signer::keypair::Keypair, system_instruction, transaction::Transaction,
+    instruction::AccountMeta, signature::Signer, signer::keypair::Keypair, system_instruction,
+    transaction::Transaction,
 };
 use utils::{program_test, Operation};
 
@@ -143,7 +144,10 @@ async fn basic_royalty_enforcement() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .additional_rule_accounts(vec![])
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            fake_token_metadata_owned_escrow.pubkey(),
+            false,
+        )])
         .build(ValidateArgs::V1 {
             operation: Operation::Transfer.to_string(),
             payload,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -3,12 +3,16 @@
 pub mod utils;
 
 use mpl_token_auth_rules::{
+    instruction::{
+        builders::{CreateBuilder, ValidateBuilder},
+        CreateArgs, InstructionBuilder, ValidateArgs,
+    },
     payload::{LeafInfo, Payload, PayloadKey, PayloadType},
     state::{Rule, RuleSet},
+    ID,
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
-use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 use solana_sdk::{
     signature::Signer, signer::keypair::Keypair, system_instruction, transaction::Transaction,
@@ -74,18 +78,21 @@ async fn basic_royalty_enforcement() {
     );
 
     // Serialize the RuleSet using RMP serde.
-    let mut serialized_data = Vec::new();
+    let mut serialized_rule_set = Vec::new();
     basic_royalty_enforcement_rule_set
-        .serialize(&mut Serializer::new(&mut serialized_data))
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = mpl_token_auth_rules::instruction::create(
-        context.payer.pubkey(),
-        rule_set_addr,
-        serialized_data,
-        vec![],
-    );
+    let create_ix = CreateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .additional_rule_accounts(vec![])
+        .build(CreateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let create_tx = Transaction::new_signed_with_payer(
@@ -134,21 +141,20 @@ async fn basic_royalty_enforcement() {
         PayloadType::Pubkey(fake_token_metadata_owned_escrow.pubkey()),
     )]);
 
-    // Create a `validate` instruction for a `Transfer` operation.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Transfer.to_string(),
-        payload,
-        false,
-        vec![AccountMeta::new_readonly(
-            fake_token_metadata_owned_escrow.pubkey(),
-            false,
-        )],
-    );
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Transfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(
@@ -197,17 +203,20 @@ async fn basic_royalty_enforcement() {
     let payload = Payload::from([(PayloadKey::Target, PayloadType::MerkleProof(leaf_info))]);
 
     // Create a `validate` instruction for a `Delegate` operation.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Delegate.to_string(),
-        payload.clone(),
-        false,
-        vec![],
-    );
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Delegate.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(
@@ -228,17 +237,20 @@ async fn basic_royalty_enforcement() {
     // Validate SaleTransfer operation
     // --------------------------------
     // Create a `validate` instruction for a `SaleTransfer` operation.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::SaleTransfer.to_string(),
-        payload,
-        false,
-        vec![],
-    );
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::SaleTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -10,7 +10,6 @@ use mpl_token_auth_rules::{
     },
     payload::{Payload, PayloadKey, PayloadType},
     state::{CompareOp, Rule, RuleSet},
-    ID,
 };
 use num_traits::cast::FromPrimitive;
 use rmp_serde::Serializer;
@@ -68,9 +67,6 @@ async fn test_payer_not_signer_fails() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::Transfer.to_string(),
@@ -183,9 +179,6 @@ async fn test_additional_signer_and_amount() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(
             context.payer.pubkey(),
             true,
@@ -229,9 +222,6 @@ async fn test_additional_signer_and_amount() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![
             AccountMeta::new_readonly(context.payer.pubkey(), true),
             AccountMeta::new_readonly(second_signer.pubkey(), true),
@@ -266,9 +256,6 @@ async fn test_additional_signer_and_amount() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![
             AccountMeta::new_readonly(context.payer.pubkey(), true),
             AccountMeta::new_readonly(second_signer.pubkey(), true),
@@ -378,9 +365,6 @@ async fn test_pass() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .payer(crate::ID)
-        .rule_authority(crate::ID)
-        .rule_set_state_pda(crate::ID)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::Transfer.to_string(),

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -4,8 +4,13 @@ pub mod utils;
 
 use mpl_token_auth_rules::{
     error::RuleSetError,
+    instruction::{
+        builders::{CreateBuilder, ValidateBuilder},
+        CreateArgs, InstructionBuilder, ValidateArgs,
+    },
     payload::{Payload, PayloadKey, PayloadType},
     state::{CompareOp, Rule, RuleSet},
+    ID,
 };
 use num_traits::cast::FromPrimitive;
 use rmp_serde::Serializer;
@@ -30,12 +35,15 @@ async fn test_payer_not_signer_fails() {
     );
 
     // Create a `create` instruction.
-    let create_ix = mpl_token_auth_rules::instruction::create(
-        context.payer.pubkey(),
-        rule_set_addr,
-        vec![],
-        vec![],
-    );
+    let create_ix = CreateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .additional_rule_accounts(vec![])
+        .build(CreateArgs::V1 {
+            serialized_rule_set: vec![],
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a non-signed transaction.
     let create_tx = Transaction::new_with_payer(&[create_ix], Some(&context.payer.pubkey()));
@@ -57,17 +65,20 @@ async fn test_payer_not_signer_fails() {
     let mint = Keypair::new().pubkey();
 
     // Create a `validate` instruction.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Transfer.to_string(),
-        Payload::default(),
-        false,
-        vec![],
-    );
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Transfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a non-signed transaction.
     let validate_tx = Transaction::new_with_payer(&[validate_ix], Some(&context.payer.pubkey()));
@@ -131,18 +142,21 @@ async fn test_additional_signer_and_amount() {
     println!("{:#?}", rule_set);
 
     // Serialize the RuleSet using RMP serde.
-    let mut serialized_data = Vec::new();
+    let mut serialized_rule_set = Vec::new();
     rule_set
-        .serialize(&mut Serializer::new(&mut serialized_data))
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = mpl_token_auth_rules::instruction::create(
-        context.payer.pubkey(),
-        rule_set_addr,
-        serialized_data,
-        vec![],
-    );
+    let create_ix = CreateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .additional_rule_accounts(vec![])
+        .build(CreateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let create_tx = Transaction::new_signed_with_payer(
@@ -166,17 +180,23 @@ async fn test_additional_signer_and_amount() {
     let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(2))]);
 
     // Create a `validate` instruction WITHOUT the second signer.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Transfer.to_string(),
-        payload.clone(),
-        false,
-        vec![AccountMeta::new_readonly(context.payer.pubkey(), true)],
-    );
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            context.payer.pubkey(),
+            true,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Transfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(
@@ -206,20 +226,23 @@ async fn test_additional_signer_and_amount() {
     }
 
     // Create a `validate` instruction WITH the second signer.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Transfer.to_string(),
-        payload,
-        false,
-        vec![
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![
             AccountMeta::new_readonly(context.payer.pubkey(), true),
             AccountMeta::new_readonly(second_signer.pubkey(), true),
-        ],
-    );
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Transfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(
@@ -240,20 +263,23 @@ async fn test_additional_signer_and_amount() {
     let payload = Payload::from([(PayloadKey::Amount, PayloadType::Number(1))]);
 
     // Create a `validate` instruction WITH the second signer.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Transfer.to_string(),
-        payload,
-        false,
-        vec![
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![
             AccountMeta::new_readonly(context.payer.pubkey(), true),
             AccountMeta::new_readonly(second_signer.pubkey(), true),
-        ],
-    );
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Transfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(
@@ -308,18 +334,21 @@ async fn test_pass() {
     println!("{:#?}", rule_set);
 
     // Serialize the RuleSet using RMP serde.
-    let mut serialized_data = Vec::new();
+    let mut serialized_rule_set = Vec::new();
     rule_set
-        .serialize(&mut Serializer::new(&mut serialized_data))
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = mpl_token_auth_rules::instruction::create(
-        context.payer.pubkey(),
-        rule_set_addr,
-        serialized_data,
-        vec![],
-    );
+    let create_ix = CreateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .additional_rule_accounts(vec![])
+        .build(CreateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let create_tx = Transaction::new_signed_with_payer(
@@ -346,17 +375,20 @@ async fn test_pass() {
     let mint = Keypair::new().pubkey();
 
     // Create a `validate` instruction.
-    let validate_ix = mpl_token_auth_rules::instruction::validate(
-        rule_set_addr,
-        mint,
-        None,
-        None,
-        None,
-        Operation::Transfer.to_string(),
-        Payload::default(),
-        false,
-        vec![],
-    );
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(crate::ID)
+        .rule_authority(crate::ID)
+        .rule_set_state_pda(crate::ID)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::Transfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
 
     // Add it to a transaction.
     let validate_tx = Transaction::new_signed_with_payer(


### PR DESCRIPTION
### Notes
* Implement Instruction Builder using proc macro imported from token-metadata [febo/accounts-context](https://github.com/metaplex-foundation/metaplex-program-library/tree/febo/accounts-context) branch.
  * Using commit hash of this branch in mpl-token-auth-rules Cargo.toml for now.
* Add `AccountContext` derivation to instruction enums.
* Port `Context` and `InstructionBuilder` structs from token-metadata (using same [febo/accounts-context](https://github.com/metaplex-foundation/metaplex-program-library/tree/febo/accounts-context) branch)
* Port `next_optional_account_info` from token-metadata.
* Add args shank annotation and implement `InstructionBuilder` trait
for `create` and `validate`.
* Modify instruction processors to use the account contexts.
* Update BPF tests to use instruction builders, all tests passing.