### PR TITLE
Add ability to update RuleSet after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ export const createTokenAuthorizationRules = async (
             systemProgram: SystemProgram.programId,
         },
         {
-            createArgs: { name, serializedRuleSet: data },
+            CreateOrUpdateArgs: { name, serializedRuleSet: data },
         },
         PROGRAM_ID,
     )

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -10,7 +10,7 @@ use solana_program::{
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Args for `create` instruction.
-pub enum CreateArgs {
+pub enum CreateOrUpdateArgs {
     V1 {
         /// RuleSet pre-serialized by caller into the MessagePack format.
         serialized_rule_set: Vec<u8>,
@@ -39,7 +39,7 @@ pub enum RuleSetInstruction {
     #[account(0, signer, writable, name="payer", desc="Payer and creator of the RuleSet")]
     #[account(1, writable, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
-    Create(CreateArgs),
+    CreateOrUpdate(CreateOrUpdateArgs),
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by calling the
     /// `RuleSet`'s `validate` method.  If any of the Rules contained in the RuleSet have state
@@ -57,8 +57,8 @@ pub enum RuleSetInstruction {
     Validate(ValidateArgs),
 }
 
-/// Builds a `create` instruction.
-impl InstructionBuilder for builders::Create {
+/// Builds a `CreateOrUpdate` instruction.
+impl InstructionBuilder for builders::CreateOrUpdate {
     fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = vec![
             AccountMeta::new(self.payer, true),
@@ -69,14 +69,14 @@ impl InstructionBuilder for builders::Create {
         Instruction {
             program_id: crate::ID,
             accounts,
-            data: RuleSetInstruction::Create(self.args.clone())
+            data: RuleSetInstruction::CreateOrUpdate(self.args.clone())
                 .try_to_vec()
                 .unwrap(),
         }
     }
 }
 
-/// Builds a `validate` instruction.
+/// Builds a `Validate` instruction.
 impl InstructionBuilder for builders::Validate {
     fn instruction(&self) -> solana_program::instruction::Instruction {
         let mut accounts = vec![

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -5,7 +5,6 @@ use shank::ShankInstruction;
 use solana_program::{
     account_info::AccountInfo,
     instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
 };
 
 #[repr(C)]
@@ -21,7 +20,6 @@ pub enum CreateArgs {
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Args for `validate` instruction.
-
 pub enum ValidateArgs {
     V1 {
         /// `Operation` to validate.
@@ -41,7 +39,6 @@ pub enum RuleSetInstruction {
     #[account(0, signer, writable, name="payer", desc="Payer and creator of the RuleSet")]
     #[account(1, writable, name="rule_set_pda", desc = "The PDA account where the RuleSet is stored")]
     #[account(2, name = "system_program", desc = "System program")]
-    #[args(additional_rule_accounts: Vec<Pubkey>)]
     Create(CreateArgs),
 
     /// This instruction executes the RuleSet stored in the rule_set PDA account by calling the
@@ -63,15 +60,11 @@ pub enum RuleSetInstruction {
 /// Builds a `create` instruction.
 impl InstructionBuilder for builders::Create {
     fn instruction(&self) -> solana_program::instruction::Instruction {
-        let mut accounts = vec![
+        let accounts = vec![
             AccountMeta::new(self.payer, true),
             AccountMeta::new(self.rule_set_pda, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
         ];
-
-        for account in self.additional_rule_accounts.iter() {
-            accounts.push(AccountMeta::new_readonly(*account, false));
-        }
 
         Instruction {
             program_id: crate::ID,

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -60,6 +60,32 @@ pub fn create_or_allocate_account_raw<'a>(
     Ok(())
 }
 
+/// Resize an account using realloc, lifted from Solana Cookbook
+#[inline(always)]
+pub fn resize_or_reallocate_account_raw<'a>(
+    target_account: &AccountInfo<'a>,
+    funding_account: &AccountInfo<'a>,
+    system_program: &AccountInfo<'a>,
+    new_size: usize,
+) -> ProgramResult {
+    let rent = Rent::get()?;
+    let new_minimum_balance = rent.minimum_balance(new_size);
+
+    let lamports_diff = new_minimum_balance.saturating_sub(target_account.lamports());
+    invoke(
+        &system_instruction::transfer(funding_account.key, target_account.key, lamports_diff),
+        &[
+            funding_account.clone(),
+            target_account.clone(),
+            system_program.clone(),
+        ],
+    )?;
+
+    target_account.realloc(new_size, false)?;
+
+    Ok(())
+}
+
 pub fn assert_derivation(
     program_id: &Pubkey,
     account: &Pubkey,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -87,7 +87,6 @@ async fn basic_royalty_enforcement() {
     let create_ix = CreateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .additional_rule_accounts(vec![])
         .build(CreateArgs::V1 {
             serialized_rule_set,
         })

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -4,8 +4,8 @@ pub mod utils;
 
 use mpl_token_auth_rules::{
     instruction::{
-        builders::{CreateBuilder, ValidateBuilder},
-        CreateArgs, InstructionBuilder, ValidateArgs,
+        builders::{CreateOrUpdateBuilder, ValidateBuilder},
+        CreateOrUpdateArgs, InstructionBuilder, ValidateArgs,
     },
     payload::{LeafInfo, Payload, PayloadKey, PayloadType},
     state::{Rule, RuleSet},
@@ -84,10 +84,10 @@ async fn basic_royalty_enforcement() {
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = CreateBuilder::new()
+    let create_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .build(CreateArgs::V1 {
+        .build(CreateOrUpdateArgs::V1 {
             serialized_rule_set,
         })
         .unwrap()

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -37,7 +37,6 @@ async fn test_payer_not_signer_fails() {
     let create_ix = CreateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .additional_rule_accounts(vec![])
         .build(CreateArgs::V1 {
             serialized_rule_set: vec![],
         })
@@ -147,7 +146,6 @@ async fn test_additional_signer_and_amount() {
     let create_ix = CreateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .additional_rule_accounts(vec![])
         .build(CreateArgs::V1 {
             serialized_rule_set,
         })
@@ -330,7 +328,6 @@ async fn test_pass() {
     let create_ix = CreateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .additional_rule_accounts(vec![])
         .build(CreateArgs::V1 {
             serialized_rule_set,
         })

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -5,8 +5,8 @@ pub mod utils;
 use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{
-        builders::{CreateBuilder, ValidateBuilder},
-        CreateArgs, InstructionBuilder, ValidateArgs,
+        builders::{CreateOrUpdateBuilder, ValidateBuilder},
+        CreateOrUpdateArgs, InstructionBuilder, ValidateArgs,
     },
     payload::{Payload, PayloadKey, PayloadType},
     state::{CompareOp, Rule, RuleSet},
@@ -34,10 +34,10 @@ async fn test_payer_not_signer_fails() {
     );
 
     // Create a `create` instruction.
-    let create_ix = CreateBuilder::new()
+    let create_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .build(CreateArgs::V1 {
+        .build(CreateOrUpdateArgs::V1 {
             serialized_rule_set: vec![],
         })
         .unwrap()
@@ -143,10 +143,10 @@ async fn test_additional_signer_and_amount() {
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = CreateBuilder::new()
+    let create_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .build(CreateArgs::V1 {
+        .build(CreateOrUpdateArgs::V1 {
             serialized_rule_set,
         })
         .unwrap()
@@ -325,10 +325,10 @@ async fn test_pass() {
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = CreateBuilder::new()
+    let create_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .build(CreateArgs::V1 {
+        .build(CreateOrUpdateArgs::V1 {
             serialized_rule_set,
         })
         .unwrap()
@@ -416,10 +416,10 @@ async fn test_update_ruleset() {
         .unwrap();
 
     // Create a `create` instruction.
-    let create_ix = CreateBuilder::new()
+    let create_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .build(CreateArgs::V1 {
+        .build(CreateOrUpdateArgs::V1 {
             serialized_rule_set,
         })
         .unwrap()
@@ -467,10 +467,10 @@ async fn test_update_ruleset() {
         .unwrap();
 
     // Create a new `create` instruction to update the RuleSet.
-    let update_ix = CreateBuilder::new()
+    let update_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
-        .build(CreateArgs::V1 {
+        .build(CreateOrUpdateArgs::V1 {
             serialized_rule_set,
         })
         .unwrap()

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -386,3 +386,108 @@ async fn test_pass() {
         .await
         .expect("validation should succeed");
 }
+
+#[tokio::test]
+async fn test_update_ruleset() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Find RuleSet PDA.
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    // Create a Pass Rule.
+    let pass_rule = Rule::Pass;
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::Transfer.to_string(), pass_rule)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // Create a `create` instruction.
+    let create_ix = CreateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .build(CreateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix.clone()],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .expect("creation should succeed");
+
+    // Create some additional rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    let amount_check = Rule::Amount {
+        amount: 1,
+        operator: CompareOp::Eq,
+    };
+
+    let overall_rule = Rule::All {
+        rules: vec![adtl_signer, amount_check],
+    };
+
+    // Create a new RuleSet.
+    let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::Transfer.to_string(), overall_rule)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // Create a new `create` instruction to update the RuleSet.
+    let update_ix = CreateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .build(CreateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let update_tx = Transaction::new_signed_with_payer(
+        &[update_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    context
+        .banks_client
+        .process_transaction(update_tx)
+        .await
+        .expect("Updating RuleSet PDA with new RuleSet should succeed");
+}


### PR DESCRIPTION
### Notes
* Remove additional rule accounts from create instruction.
* Add ability to update `RuleSet` after creation.
* Rename `Create` to `CreateOrUpdate` to match new functionality.