### PR TITLE
Fix js package root path

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,7 +20,7 @@
     "fix": "yarn fix:lint && yarn fix:prettier"
   },
   "files": [
-    "/dist"
+    "/dist/src"
   ],
   "publishConfig": {
     "access": "public",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "rootDir": "./src"
-  }
+    "rootDir": "."
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Currently the JS package is broken since the `src` folder is "missing". This PR changes the `tsconfig.json` to fix the root folder for yarn build.