### PR TITLE
Change value to match program

### DIFF
--- a/packages/sdk/src/mpl-token-auth-rules.ts
+++ b/packages/sdk/src/mpl-token-auth-rules.ts
@@ -2,4 +2,4 @@ export * from './errors';
 // @ts-ignore
 export * from './generated';
 
-export const PREFIX = 'ruleset';
+export const PREFIX = 'rule_set';

--- a/packages/sdk/src/mpl-token-authorization-rules.ts
+++ b/packages/sdk/src/mpl-token-authorization-rules.ts
@@ -2,4 +2,4 @@ export * from './errors';
 // @ts-ignore
 export * from './generated';
 
-export const PREFIX = 'ruleset';
+export const PREFIX = 'rule_set';


### PR DESCRIPTION
PR to fix the JS `PREFIX` value – currently the JS `PREFIX` constant does not match the program value (`ruleset` instead of `rule_set`).