### PR TITLE
Add `ProgramOwnedList` Rule and Composed `RuleSets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ fn main() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), overall_rule)
+        .add(Operation::OwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -198,7 +198,7 @@ fn main() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(adtl_signer.pubkey(), true)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -333,76 +333,86 @@
     },
     {
       "code": 11,
+      "name": "ProgramOwnedListCheckFailed",
+      "msg": "Program Owned List check failed"
+    },
+    {
+      "code": 12,
+      "name": "ProgramOwnedTreeCheckFailed",
+      "msg": "Program Owned Tree check failed"
+    },
+    {
+      "code": 13,
       "name": "AmountCheckFailed",
       "msg": "Amount checked failed"
     },
     {
-      "code": 12,
+      "code": 14,
       "name": "FrequencyCheckFailed",
       "msg": "Frequency check failed"
     },
     {
-      "code": 13,
+      "code": 15,
       "name": "PayerIsNotSigner",
       "msg": "Payer is not a signer"
     },
     {
-      "code": 14,
+      "code": 16,
       "name": "NotImplemented",
       "msg": "Not implemented"
     },
     {
-      "code": 15,
+      "code": 17,
       "name": "BorshSerializationError",
       "msg": "Borsh serialization error"
     },
     {
-      "code": 16,
+      "code": 18,
       "name": "ValueOccupied",
       "msg": "Value in Payload or RuleSet is occupied"
     },
     {
-      "code": 17,
+      "code": 19,
       "name": "DataIsEmpty",
       "msg": "Account data is empty"
     },
     {
-      "code": 18,
+      "code": 20,
       "name": "MessagePackDeserializationError",
       "msg": "MessagePack deserialization error"
     },
     {
-      "code": 19,
+      "code": 21,
       "name": "MissingAccount",
       "msg": "Missing account"
     },
     {
-      "code": 20,
+      "code": 22,
       "name": "MissingPayloadValue",
       "msg": "Missing Payload value"
     },
     {
-      "code": 21,
+      "code": 23,
       "name": "RuleSetOwnerMismatch",
       "msg": "RuleSet owner must be payer"
     },
     {
-      "code": 22,
+      "code": 24,
       "name": "NameTooLong",
       "msg": "Name too long"
     },
     {
-      "code": 23,
+      "code": 25,
       "name": "OperationNotFound",
       "msg": "The operation retrieved is not in the selected RuleSet"
     },
     {
-      "code": 24,
+      "code": 26,
       "name": "RuleAuthorityIsNotSigner",
       "msg": "Rule authority is not signer"
     },
     {
-      "code": 25,
+      "code": 27,
       "name": "UnsupportedRuleSetVersion",
       "msg": "Unsupported RuleSet version"
     }

--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -415,6 +415,11 @@
       "code": 27,
       "name": "UnsupportedRuleSetVersion",
       "msg": "Unsupported RuleSet version"
+    },
+    {
+      "code": 28,
+      "name": "UnexpectedRuleSetFailure",
+      "msg": "Unexpected RuleSet failure"
     }
   ],
   "metadata": {

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -241,13 +241,59 @@ createErrorFromCodeLookup.set(0xa, () => new ProgramOwnedCheckFailedError());
 createErrorFromNameLookup.set('ProgramOwnedCheckFailed', () => new ProgramOwnedCheckFailedError());
 
 /**
+ * ProgramOwnedListCheckFailed: 'Program Owned List check failed'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class ProgramOwnedListCheckFailedError extends Error {
+  readonly code: number = 0xb;
+  readonly name: string = 'ProgramOwnedListCheckFailed';
+  constructor() {
+    super('Program Owned List check failed');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, ProgramOwnedListCheckFailedError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0xb, () => new ProgramOwnedListCheckFailedError());
+createErrorFromNameLookup.set(
+  'ProgramOwnedListCheckFailed',
+  () => new ProgramOwnedListCheckFailedError(),
+);
+
+/**
+ * ProgramOwnedTreeCheckFailed: 'Program Owned Tree check failed'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class ProgramOwnedTreeCheckFailedError extends Error {
+  readonly code: number = 0xc;
+  readonly name: string = 'ProgramOwnedTreeCheckFailed';
+  constructor() {
+    super('Program Owned Tree check failed');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, ProgramOwnedTreeCheckFailedError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0xc, () => new ProgramOwnedTreeCheckFailedError());
+createErrorFromNameLookup.set(
+  'ProgramOwnedTreeCheckFailed',
+  () => new ProgramOwnedTreeCheckFailedError(),
+);
+
+/**
  * AmountCheckFailed: 'Amount checked failed'
  *
  * @category Errors
  * @category generated
  */
 export class AmountCheckFailedError extends Error {
-  readonly code: number = 0xb;
+  readonly code: number = 0xd;
   readonly name: string = 'AmountCheckFailed';
   constructor() {
     super('Amount checked failed');
@@ -257,7 +303,7 @@ export class AmountCheckFailedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0xb, () => new AmountCheckFailedError());
+createErrorFromCodeLookup.set(0xd, () => new AmountCheckFailedError());
 createErrorFromNameLookup.set('AmountCheckFailed', () => new AmountCheckFailedError());
 
 /**
@@ -267,7 +313,7 @@ createErrorFromNameLookup.set('AmountCheckFailed', () => new AmountCheckFailedEr
  * @category generated
  */
 export class FrequencyCheckFailedError extends Error {
-  readonly code: number = 0xc;
+  readonly code: number = 0xe;
   readonly name: string = 'FrequencyCheckFailed';
   constructor() {
     super('Frequency check failed');
@@ -277,7 +323,7 @@ export class FrequencyCheckFailedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0xc, () => new FrequencyCheckFailedError());
+createErrorFromCodeLookup.set(0xe, () => new FrequencyCheckFailedError());
 createErrorFromNameLookup.set('FrequencyCheckFailed', () => new FrequencyCheckFailedError());
 
 /**
@@ -287,7 +333,7 @@ createErrorFromNameLookup.set('FrequencyCheckFailed', () => new FrequencyCheckFa
  * @category generated
  */
 export class PayerIsNotSignerError extends Error {
-  readonly code: number = 0xd;
+  readonly code: number = 0xf;
   readonly name: string = 'PayerIsNotSigner';
   constructor() {
     super('Payer is not a signer');
@@ -297,7 +343,7 @@ export class PayerIsNotSignerError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0xd, () => new PayerIsNotSignerError());
+createErrorFromCodeLookup.set(0xf, () => new PayerIsNotSignerError());
 createErrorFromNameLookup.set('PayerIsNotSigner', () => new PayerIsNotSignerError());
 
 /**
@@ -307,7 +353,7 @@ createErrorFromNameLookup.set('PayerIsNotSigner', () => new PayerIsNotSignerErro
  * @category generated
  */
 export class NotImplementedError extends Error {
-  readonly code: number = 0xe;
+  readonly code: number = 0x10;
   readonly name: string = 'NotImplemented';
   constructor() {
     super('Not implemented');
@@ -317,7 +363,7 @@ export class NotImplementedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0xe, () => new NotImplementedError());
+createErrorFromCodeLookup.set(0x10, () => new NotImplementedError());
 createErrorFromNameLookup.set('NotImplemented', () => new NotImplementedError());
 
 /**
@@ -327,7 +373,7 @@ createErrorFromNameLookup.set('NotImplemented', () => new NotImplementedError())
  * @category generated
  */
 export class BorshSerializationErrorError extends Error {
-  readonly code: number = 0xf;
+  readonly code: number = 0x11;
   readonly name: string = 'BorshSerializationError';
   constructor() {
     super('Borsh serialization error');
@@ -337,7 +383,7 @@ export class BorshSerializationErrorError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0xf, () => new BorshSerializationErrorError());
+createErrorFromCodeLookup.set(0x11, () => new BorshSerializationErrorError());
 createErrorFromNameLookup.set('BorshSerializationError', () => new BorshSerializationErrorError());
 
 /**
@@ -347,7 +393,7 @@ createErrorFromNameLookup.set('BorshSerializationError', () => new BorshSerializ
  * @category generated
  */
 export class ValueOccupiedError extends Error {
-  readonly code: number = 0x10;
+  readonly code: number = 0x12;
   readonly name: string = 'ValueOccupied';
   constructor() {
     super('Value in Payload or RuleSet is occupied');
@@ -357,7 +403,7 @@ export class ValueOccupiedError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x10, () => new ValueOccupiedError());
+createErrorFromCodeLookup.set(0x12, () => new ValueOccupiedError());
 createErrorFromNameLookup.set('ValueOccupied', () => new ValueOccupiedError());
 
 /**
@@ -367,7 +413,7 @@ createErrorFromNameLookup.set('ValueOccupied', () => new ValueOccupiedError());
  * @category generated
  */
 export class DataIsEmptyError extends Error {
-  readonly code: number = 0x11;
+  readonly code: number = 0x13;
   readonly name: string = 'DataIsEmpty';
   constructor() {
     super('Account data is empty');
@@ -377,7 +423,7 @@ export class DataIsEmptyError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x11, () => new DataIsEmptyError());
+createErrorFromCodeLookup.set(0x13, () => new DataIsEmptyError());
 createErrorFromNameLookup.set('DataIsEmpty', () => new DataIsEmptyError());
 
 /**
@@ -387,7 +433,7 @@ createErrorFromNameLookup.set('DataIsEmpty', () => new DataIsEmptyError());
  * @category generated
  */
 export class MessagePackDeserializationErrorError extends Error {
-  readonly code: number = 0x12;
+  readonly code: number = 0x14;
   readonly name: string = 'MessagePackDeserializationError';
   constructor() {
     super('MessagePack deserialization error');
@@ -397,7 +443,7 @@ export class MessagePackDeserializationErrorError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x12, () => new MessagePackDeserializationErrorError());
+createErrorFromCodeLookup.set(0x14, () => new MessagePackDeserializationErrorError());
 createErrorFromNameLookup.set(
   'MessagePackDeserializationError',
   () => new MessagePackDeserializationErrorError(),
@@ -410,7 +456,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class MissingAccountError extends Error {
-  readonly code: number = 0x13;
+  readonly code: number = 0x15;
   readonly name: string = 'MissingAccount';
   constructor() {
     super('Missing account');
@@ -420,7 +466,7 @@ export class MissingAccountError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x13, () => new MissingAccountError());
+createErrorFromCodeLookup.set(0x15, () => new MissingAccountError());
 createErrorFromNameLookup.set('MissingAccount', () => new MissingAccountError());
 
 /**
@@ -430,7 +476,7 @@ createErrorFromNameLookup.set('MissingAccount', () => new MissingAccountError())
  * @category generated
  */
 export class MissingPayloadValueError extends Error {
-  readonly code: number = 0x14;
+  readonly code: number = 0x16;
   readonly name: string = 'MissingPayloadValue';
   constructor() {
     super('Missing Payload value');
@@ -440,7 +486,7 @@ export class MissingPayloadValueError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x14, () => new MissingPayloadValueError());
+createErrorFromCodeLookup.set(0x16, () => new MissingPayloadValueError());
 createErrorFromNameLookup.set('MissingPayloadValue', () => new MissingPayloadValueError());
 
 /**
@@ -450,7 +496,7 @@ createErrorFromNameLookup.set('MissingPayloadValue', () => new MissingPayloadVal
  * @category generated
  */
 export class RuleSetOwnerMismatchError extends Error {
-  readonly code: number = 0x15;
+  readonly code: number = 0x17;
   readonly name: string = 'RuleSetOwnerMismatch';
   constructor() {
     super('RuleSet owner must be payer');
@@ -460,7 +506,7 @@ export class RuleSetOwnerMismatchError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x15, () => new RuleSetOwnerMismatchError());
+createErrorFromCodeLookup.set(0x17, () => new RuleSetOwnerMismatchError());
 createErrorFromNameLookup.set('RuleSetOwnerMismatch', () => new RuleSetOwnerMismatchError());
 
 /**
@@ -470,7 +516,7 @@ createErrorFromNameLookup.set('RuleSetOwnerMismatch', () => new RuleSetOwnerMism
  * @category generated
  */
 export class NameTooLongError extends Error {
-  readonly code: number = 0x16;
+  readonly code: number = 0x18;
   readonly name: string = 'NameTooLong';
   constructor() {
     super('Name too long');
@@ -480,7 +526,7 @@ export class NameTooLongError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x16, () => new NameTooLongError());
+createErrorFromCodeLookup.set(0x18, () => new NameTooLongError());
 createErrorFromNameLookup.set('NameTooLong', () => new NameTooLongError());
 
 /**
@@ -490,7 +536,7 @@ createErrorFromNameLookup.set('NameTooLong', () => new NameTooLongError());
  * @category generated
  */
 export class OperationNotFoundError extends Error {
-  readonly code: number = 0x17;
+  readonly code: number = 0x19;
   readonly name: string = 'OperationNotFound';
   constructor() {
     super('The operation retrieved is not in the selected RuleSet');
@@ -500,7 +546,7 @@ export class OperationNotFoundError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x17, () => new OperationNotFoundError());
+createErrorFromCodeLookup.set(0x19, () => new OperationNotFoundError());
 createErrorFromNameLookup.set('OperationNotFound', () => new OperationNotFoundError());
 
 /**
@@ -510,7 +556,7 @@ createErrorFromNameLookup.set('OperationNotFound', () => new OperationNotFoundEr
  * @category generated
  */
 export class RuleAuthorityIsNotSignerError extends Error {
-  readonly code: number = 0x18;
+  readonly code: number = 0x1a;
   readonly name: string = 'RuleAuthorityIsNotSigner';
   constructor() {
     super('Rule authority is not signer');
@@ -520,7 +566,7 @@ export class RuleAuthorityIsNotSignerError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x18, () => new RuleAuthorityIsNotSignerError());
+createErrorFromCodeLookup.set(0x1a, () => new RuleAuthorityIsNotSignerError());
 createErrorFromNameLookup.set(
   'RuleAuthorityIsNotSigner',
   () => new RuleAuthorityIsNotSignerError(),
@@ -533,7 +579,7 @@ createErrorFromNameLookup.set(
  * @category generated
  */
 export class UnsupportedRuleSetVersionError extends Error {
-  readonly code: number = 0x19;
+  readonly code: number = 0x1b;
   readonly name: string = 'UnsupportedRuleSetVersion';
   constructor() {
     super('Unsupported RuleSet version');
@@ -543,7 +589,7 @@ export class UnsupportedRuleSetVersionError extends Error {
   }
 }
 
-createErrorFromCodeLookup.set(0x19, () => new UnsupportedRuleSetVersionError());
+createErrorFromCodeLookup.set(0x1b, () => new UnsupportedRuleSetVersionError());
 createErrorFromNameLookup.set(
   'UnsupportedRuleSetVersion',
   () => new UnsupportedRuleSetVersionError(),

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -596,6 +596,29 @@ createErrorFromNameLookup.set(
 );
 
 /**
+ * UnexpectedRuleSetFailure: 'Unexpected RuleSet failure'
+ *
+ * @category Errors
+ * @category generated
+ */
+export class UnexpectedRuleSetFailureError extends Error {
+  readonly code: number = 0x1c;
+  readonly name: string = 'UnexpectedRuleSetFailure';
+  constructor() {
+    super('Unexpected RuleSet failure');
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, UnexpectedRuleSetFailureError);
+    }
+  }
+}
+
+createErrorFromCodeLookup.set(0x1c, () => new UnexpectedRuleSetFailureError());
+createErrorFromNameLookup.set(
+  'UnexpectedRuleSetFailure',
+  () => new UnexpectedRuleSetFailureError(),
+);
+
+/**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors
  * @category generated

--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-validator",
+ "spl-associated-token-account",
  "spl-token",
  "thiserror",
 ]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -35,6 +35,7 @@ solana-logger = "=1.13.5"
 spl-token = { version = "3.5.0", features = [ "no-entrypoint" ] }
 mpl-token-metadata = { version = "1", features = [ "no-entrypoint" ] }
 serde_json = "1.0.87"
+spl-associated-token-account = { version = "1.1.1", features = ["no-entrypoint"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -121,6 +121,10 @@ pub enum RuleSetError {
     /// 27 - Unsupported RuleSet version
     #[error("Unsupported RuleSet version")]
     UnsupportedRuleSetVersion,
+
+    /// 28 - Unexpected RuleSet failure
+    #[error("Unexpected RuleSet failure")]
+    UnexpectedRuleSetFailure,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -54,63 +54,71 @@ pub enum RuleSetError {
     #[error("Program Owned check failed")]
     ProgramOwnedCheckFailed,
 
-    /// 11 - Amount checked failed
+    /// 11 - Program Owned List check failed
+    #[error("Program Owned List check failed")]
+    ProgramOwnedListCheckFailed,
+
+    /// 12 - Program Owned Tree check failed
+    #[error("Program Owned Tree check failed")]
+    ProgramOwnedTreeCheckFailed,
+
+    /// 13 - Amount checked failed
     #[error("Amount checked failed")]
     AmountCheckFailed,
 
-    /// 12 - Frequency check failed
+    /// 14 - Frequency check failed
     #[error("Frequency check failed")]
     FrequencyCheckFailed,
 
-    /// 13 - Payer is not a signer
+    /// 15 - Payer is not a signer
     #[error("Payer is not a signer")]
     PayerIsNotSigner,
 
-    /// 14 - Feature is not implemented yet
+    /// 16 - Feature is not implemented yet
     #[error("Not implemented")]
     NotImplemented,
 
-    /// 15 - Borsh serialization error
+    /// 17 - Borsh serialization error
     #[error("Borsh serialization error")]
     BorshSerializationError,
 
-    /// 16 - Value in Payload or RuleSet is occupied
+    /// 18 - Value in Payload or RuleSet is occupied
     #[error("Value in Payload or RuleSet is occupied")]
     ValueOccupied,
 
-    /// 17 - Account data is empty
+    /// 19 - Account data is empty
     #[error("Account data is empty")]
     DataIsEmpty,
 
-    /// 18 - MessagePack deserialization error
+    /// 20 - MessagePack deserialization error
     #[error("MessagePack deserialization error")]
     MessagePackDeserializationError,
 
-    /// 19 - Missing account
+    /// 21 - Missing account
     #[error("Missing account")]
     MissingAccount,
 
-    /// 20 - Missing Payload value
+    /// 22 - Missing Payload value
     #[error("Missing Payload value")]
     MissingPayloadValue,
 
-    /// 21 - RuleSet owner must be payer
+    /// 23 - RuleSet owner must be payer
     #[error("RuleSet owner must be payer")]
     RuleSetOwnerMismatch,
 
-    /// 22 - Name too long
+    /// 24 - Name too long
     #[error("Name too long")]
     NameTooLong,
 
-    /// 23 - Name too long
+    /// 25 - Name too long
     #[error("The operation retrieved is not in the selected RuleSet")]
     OperationNotFound,
 
-    /// 24 - Rule authority is not signer
+    /// 26 - Rule authority is not signer
     #[error("Rule authority is not signer")]
     RuleAuthorityIsNotSigner,
 
-    /// 25 - Unsupported RuleSet version
+    /// 27 - Unsupported RuleSet version
     #[error("Unsupported RuleSet version")]
     UnsupportedRuleSetVersion,
 }

--- a/program/tests/additional_signer.rs
+++ b/program/tests/additional_signer.rs
@@ -32,7 +32,7 @@ async fn test_additional_signer() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), adtl_signer_rule)
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -53,7 +53,7 @@ async fn test_additional_signer() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
         })
@@ -75,7 +75,7 @@ async fn test_additional_signer() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(adtl_signer.pubkey(), false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
         })
@@ -97,7 +97,7 @@ async fn test_additional_signer() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(adtl_signer.pubkey(), true)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
         })

--- a/program/tests/all.rs
+++ b/program/tests/all.rs
@@ -42,7 +42,7 @@ async fn test_all() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), overall_rule)
+        .add(Operation::OwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -69,7 +69,7 @@ async fn test_all() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
         })
@@ -97,7 +97,7 @@ async fn test_all() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/amount.rs
+++ b/program/tests/amount.rs
@@ -65,7 +65,7 @@ async fn parametric_amount_check(
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), less_than_amount_check)
+        .add(Operation::OwnerTransfer.to_string(), less_than_amount_check)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -92,7 +92,7 @@ async fn parametric_amount_check(
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -120,7 +120,7 @@ async fn parametric_amount_check(
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/any.rs
+++ b/program/tests/any.rs
@@ -40,7 +40,7 @@ async fn test_any() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), overall_rule)
+        .add(Operation::OwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -64,7 +64,7 @@ async fn test_any() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -89,7 +89,7 @@ async fn test_any() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -81,8 +81,8 @@ async fn wallet_to_pda_or_pda_to_wallet() {
     // Create RuleSet
     // --------------------------------
     // Compose the Owner Transfer rule as follows:
-    // (source is a wallet && destination is on allow list && destination is a PDA) ||
-    // (source is on allow list && source is a PDA && destination is a wallet)
+    // (source is owned by system program && dest is on allow list && destination is a PDA) ||
+    // (source is on allow list && source is a PDA && dest is owned by system program)
     let transfer_rule = Rule::Any {
         rules: vec![
             Rule::All {
@@ -230,8 +230,8 @@ async fn wallet_or_pda_to_wallet_or_pda() {
     // Create RuleSet
     // --------------------------------
     // Compose the Owner Transfer rule as follows:
-    // (source is a wallet || (source is on allow list && source is a PDA) &&
-    // (dest is a wallet || (dest is on allow list && dest is a PDA)
+    // (source is owned by system program || (source is on allow list && source is a PDA) &&
+    // (dest is owned by system program || (dest is on allow list && dest is a PDA)
     let transfer_rule = Rule::All {
         rules: vec![
             Rule::Any {
@@ -591,7 +591,7 @@ async fn multiple_operations() {
     // Create RuleSet
     // --------------------------------
     // Compose the Owner Transfer rule as follows:
-    // (source is a wallet && dest is on allow list && dest is a PDA)
+    // (source is a owned by system program && dest is on allow list && dest is a PDA)
     let transfer_rule = Rule::All {
         rules: vec![
             source_owned_by_sys_program,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -79,6 +79,30 @@ async fn basic_royalty_enforcement() {
         ],
     };
 
+    // Alternative RuleSet:
+    // (source is a wallet || (source is on allow list && source is a PDA) &&
+    // (dest is a wallet || (dest is on allow list && dest is a PDA)
+    // let transfer_rule = Rule::All {
+    //     rules: vec![
+    //         Rule::Any {
+    //             rules: vec![
+    //                 source_owned_by_sys_program,
+    //                 Rule::All {
+    //                     rules: vec![source_program_allow_list, source_pda_match],
+    //                 },
+    //             ],
+    //         },
+    //         Rule::Any {
+    //             rules: vec![
+    //                 dest_owned_by_sys_program,
+    //                 Rule::All {
+    //                     rules: vec![dest_program_allow_list, dest_pda_match],
+    //                 },
+    //             ],
+    //         },
+    //     ],
+    // };
+
     // Merkle tree root generated in a different test program.
     let marketplace_tree_root: [u8; 32] = [
         132, 141, 27, 31, 23, 154, 145, 128, 32, 62, 122, 224, 248, 128, 37, 139, 200, 46, 163,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -86,8 +86,12 @@ async fn sys_prog_owned_or_owned_pda_to_sys_prog_owned_or_owned_pda() {
     // Create RuleSet
     // --------------------------------
     // Compose the Owner Transfer rule as follows:
+    // amount is 1 &&
     // (source is owned by system program || (source is on allow list && source is a PDA) &&
     // (dest is owned by system program || (dest is on allow list && dest is a PDA)
+    //
+    // NOTE ownership by System Program is NOT sufficient to prove an account is a wallet
+    // (on-curve) instead of a PDA!
     let transfer_rule = Rule::All {
         rules: vec![
             nft_amount,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -57,7 +57,7 @@ async fn basic_royalty_enforcement() {
         field: PayloadKey::Destination.to_string(),
     };
 
-    // Compose the transfer rule as follows:
+    // Compose the Owner Transfer rule as follows:
     // (source is a wallet && destination is on allow list && destination is a PDA) ||
     // (source is on allow list && source is a PDA && destination is a wallet)
     let transfer_rule = Rule::Any {
@@ -79,7 +79,7 @@ async fn basic_royalty_enforcement() {
         ],
     };
 
-    // Alternative RuleSet:
+    // Alternative Transfer Rule:
     // (source is a wallet || (source is on allow list && source is a PDA) &&
     // (dest is a wallet || (dest is on allow list && dest is a PDA)
     // let transfer_rule = Rule::All {

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -3,60 +3,83 @@
 pub mod utils;
 
 use mpl_token_auth_rules::{
+    error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{LeafInfo, Payload, PayloadType, SeedsVec},
     state::{Rule, RuleSet},
 };
 use solana_program::{pubkey::Pubkey, system_program};
 use solana_program_test::tokio;
-use solana_sdk::{instruction::AccountMeta, signature::Signer, signer::keypair::Keypair};
+use solana_sdk::{
+    instruction::AccountMeta, signature::Signer, signer::keypair::Keypair, system_instruction,
+    transaction::Transaction,
+};
 use utils::{
-    create_rule_set_on_chain, process_passing_validate_ix, program_test, Operation, PayloadKey,
+    assert_rule_set_error, create_associated_token_account, create_mint, create_rule_set_on_chain,
+    process_failing_validate_ix, process_passing_validate_ix, program_test, Operation, PayloadKey,
 };
 
+static PROGRAM_ALLOW_LIST: [Pubkey; 1] = [mpl_token_auth_rules::ID];
+
+macro_rules! get_primitive_rules {
+    (
+        $source_owned_by_sys_program:ident,
+        $dest_program_allow_list:ident,
+        $dest_pda_match:ident,
+        $source_program_allow_list:ident,
+        $source_pda_match:ident,
+        $dest_owned_by_sys_program:ident,
+    ) => {
+        let $source_owned_by_sys_program = Rule::ProgramOwned {
+            program: system_program::ID,
+            field: PayloadKey::Source.to_string(),
+        };
+
+        let $dest_program_allow_list = Rule::ProgramOwnedList {
+            programs: PROGRAM_ALLOW_LIST.to_vec(),
+            field: PayloadKey::Destination.to_string(),
+        };
+
+        let $dest_pda_match = Rule::PDAMatch {
+            program: None,
+            pda_field: PayloadKey::Destination.to_string(),
+            seeds_field: PayloadKey::DestinationSeeds.to_string(),
+        };
+
+        let $source_program_allow_list = Rule::ProgramOwnedList {
+            programs: PROGRAM_ALLOW_LIST.to_vec(),
+            field: PayloadKey::Source.to_string(),
+        };
+
+        let $source_pda_match = Rule::PDAMatch {
+            program: None,
+            pda_field: PayloadKey::Source.to_string(),
+            seeds_field: PayloadKey::SourceSeeds.to_string(),
+        };
+
+        let $dest_owned_by_sys_program = Rule::ProgramOwned {
+            program: system_program::ID,
+            field: PayloadKey::Destination.to_string(),
+        };
+    };
+}
+
 #[tokio::test]
-async fn basic_royalty_enforcement() {
+async fn wallet_to_pda_or_pda_to_wallet() {
     let mut context = program_test().start_with_context().await;
+
+    get_primitive_rules!(
+        source_owned_by_sys_program,
+        dest_program_allow_list,
+        dest_pda_match,
+        source_program_allow_list,
+        source_pda_match,
+        dest_owned_by_sys_program,
+    );
 
     // --------------------------------
     // Create RuleSet
     // --------------------------------
-    static PROGRAM_ALLOW_LIST: [Pubkey; 1] = [mpl_token_auth_rules::ID];
-
-    // OwnerTransfer out rules.
-    let source_owned_by_sys_program = Rule::ProgramOwned {
-        program: system_program::ID,
-        field: PayloadKey::Source.to_string(),
-    };
-
-    let dest_program_allow_list = Rule::ProgramOwnedList {
-        programs: PROGRAM_ALLOW_LIST.to_vec(),
-        field: PayloadKey::Destination.to_string(),
-    };
-
-    let dest_pda_match = Rule::PDAMatch {
-        program: None,
-        pda_field: PayloadKey::Destination.to_string(),
-        seeds_field: PayloadKey::DestinationSeeds.to_string(),
-    };
-
-    // OwnerTransfer back rules.
-    let source_program_allow_list = Rule::ProgramOwnedList {
-        programs: PROGRAM_ALLOW_LIST.to_vec(),
-        field: PayloadKey::Source.to_string(),
-    };
-
-    let source_pda_match = Rule::PDAMatch {
-        program: None,
-        pda_field: PayloadKey::Source.to_string(),
-        seeds_field: PayloadKey::SourceSeeds.to_string(),
-    };
-
-    let dest_owned_by_sys_program = Rule::ProgramOwned {
-        program: system_program::ID,
-        field: PayloadKey::Destination.to_string(),
-    };
-
     // Compose the Owner Transfer rule as follows:
     // (source is a wallet && destination is on allow list && destination is a PDA) ||
     // (source is on allow list && source is a PDA && destination is a wallet)
@@ -79,85 +102,33 @@ async fn basic_royalty_enforcement() {
         ],
     };
 
-    // Alternative Transfer Rule:
-    // (source is a wallet || (source is on allow list && source is a PDA) &&
-    // (dest is a wallet || (dest is on allow list && dest is a PDA)
-    // let transfer_rule = Rule::All {
-    //     rules: vec![
-    //         Rule::Any {
-    //             rules: vec![
-    //                 source_owned_by_sys_program,
-    //                 Rule::All {
-    //                     rules: vec![source_program_allow_list, source_pda_match],
-    //                 },
-    //             ],
-    //         },
-    //         Rule::Any {
-    //             rules: vec![
-    //                 dest_owned_by_sys_program,
-    //                 Rule::All {
-    //                     rules: vec![dest_program_allow_list, dest_pda_match],
-    //                 },
-    //             ],
-    //         },
-    //     ],
-    // };
-
-    // Merkle tree root generated in a different test program.
-    let marketplace_tree_root: [u8; 32] = [
-        132, 141, 27, 31, 23, 154, 145, 128, 32, 62, 122, 224, 248, 128, 37, 139, 200, 46, 163,
-        238, 76, 123, 155, 141, 73, 12, 111, 192, 122, 80, 126, 155,
-    ];
-
-    // Rule for Delegate and SaleTransfer: The provided leaf node must be a
-    // member of the marketplace Merkle tree.
-    let leaf_in_marketplace_tree = Rule::PubkeyTreeMatch {
-        root: marketplace_tree_root,
-        field: PayloadKey::Destination.to_string(),
-    };
-
-    // Create Basic Royalty Enforcement RuleSet.
-    let mut basic_royalty_enforcement_rule_set = RuleSet::new(
+    // Create RuleSet.
+    let mut rule_set = RuleSet::new(
         "basic_royalty_enforcement".to_string(),
         context.payer.pubkey(),
     );
-    basic_royalty_enforcement_rule_set
+    rule_set
         .add(Operation::OwnerTransfer.to_string(), transfer_rule)
         .unwrap();
-    basic_royalty_enforcement_rule_set
-        .add(
-            Operation::Delegate.to_string(),
-            leaf_in_marketplace_tree.clone(),
-        )
-        .unwrap();
-    basic_royalty_enforcement_rule_set
-        .add(
-            Operation::SaleTransfer.to_string(),
-            leaf_in_marketplace_tree,
-        )
-        .unwrap();
 
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&basic_royalty_enforcement_rule_set,).unwrap()
-    );
+    println!("{}", serde_json::to_string_pretty(&rule_set,).unwrap());
 
     // Put the RuleSet on chain.
     let rule_set_addr = create_rule_set_on_chain(
         &mut context,
-        basic_royalty_enforcement_rule_set,
+        rule_set,
         "basic_royalty_enforcement".to_string(),
     )
     .await;
 
     // --------------------------------
-    // Validate Transfer to a PDA.
+    // Validate Wallet to a PDA
     // --------------------------------
     // Create a Keypair to simulate an owner's wallet.
-    let wallet = Keypair::new().pubkey();
+    let wallet = Keypair::new();
 
     // Create a Keypair to simulate a token mint address.
-    let mint = Keypair::new().pubkey();
+    let mint = Keypair::new();
 
     // Our derived key is going to be an account owned by the
     // mpl-token-auth-rules program. Any one will do so for convenience
@@ -169,10 +140,13 @@ async fn basic_royalty_enforcement() {
     ];
 
     // Store the payload of data to validate against the rule definition.  In this case the
-    // `Destination` will be used to look up the `AccountInfo` and see and see who the owner
-    // is, and the `DestinationSeeds` provide the seeds for the PDA derivation.
+    // `Destination` Pubkey will be used to look up the `AccountInfo` and see and see who the
+    // owner is, and the `DestinationSeeds` provide the seeds for the PDA derivation.
     let payload = Payload::from([
-        (PayloadKey::Source.to_string(), PayloadType::Pubkey(wallet)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(wallet.pubkey()),
+        ),
         (
             PayloadKey::Destination.to_string(),
             PayloadType::Pubkey(rule_set_addr),
@@ -185,9 +159,9 @@ async fn basic_royalty_enforcement() {
 
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
-        .mint(mint)
+        .mint(mint.pubkey())
         .additional_rule_accounts(vec![
-            AccountMeta::new_readonly(wallet, false),
+            AccountMeta::new_readonly(wallet.pubkey(), false),
             AccountMeta::new_readonly(rule_set_addr, false),
         ])
         .build(ValidateArgs::V1 {
@@ -198,15 +172,13 @@ async fn basic_royalty_enforcement() {
         .unwrap()
         .instruction();
 
-    // Validate Transfer operation.
+    // Validate OwnerTransfer operation.
     process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
-    // Validate Transfer to a wallet.
+    // Validate PDA to wallet
     // --------------------------------
     // Store the payload of data to validate against the rule definition.
-    // In this case the Target will be used to look up the `AccountInfo`
-    // and see who the owner is.
     let payload = Payload::from([
         (
             PayloadKey::Source.to_string(),
@@ -218,16 +190,16 @@ async fn basic_royalty_enforcement() {
         ),
         (
             PayloadKey::Destination.to_string(),
-            PayloadType::Pubkey(wallet),
+            PayloadType::Pubkey(wallet.pubkey()),
         ),
     ]);
 
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
-        .mint(mint)
+        .mint(mint.pubkey())
         .additional_rule_accounts(vec![
             AccountMeta::new_readonly(rule_set_addr, false),
-            AccountMeta::new_readonly(wallet, false),
+            AccountMeta::new_readonly(wallet.pubkey(), false),
         ])
         .build(ValidateArgs::V1 {
             operation: Operation::OwnerTransfer.to_string(),
@@ -237,8 +209,529 @@ async fn basic_royalty_enforcement() {
         .unwrap()
         .instruction();
 
-    // Validate Transfer operation.
+    // Validate OwnerTransfer operation.
     process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+}
+
+#[tokio::test]
+async fn wallet_or_pda_to_wallet_or_pda() {
+    let mut context = program_test().start_with_context().await;
+
+    get_primitive_rules!(
+        source_owned_by_sys_program,
+        dest_program_allow_list,
+        dest_pda_match,
+        source_program_allow_list,
+        source_pda_match,
+        dest_owned_by_sys_program,
+    );
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Compose the Owner Transfer rule as follows:
+    // (source is a wallet || (source is on allow list && source is a PDA) &&
+    // (dest is a wallet || (dest is on allow list && dest is a PDA)
+    let transfer_rule = Rule::All {
+        rules: vec![
+            Rule::Any {
+                rules: vec![
+                    source_owned_by_sys_program,
+                    Rule::All {
+                        rules: vec![source_program_allow_list, source_pda_match],
+                    },
+                ],
+            },
+            Rule::Any {
+                rules: vec![
+                    dest_owned_by_sys_program,
+                    Rule::All {
+                        rules: vec![dest_program_allow_list, dest_pda_match],
+                    },
+                ],
+            },
+        ],
+    };
+
+    // Create RuleSet.
+    let mut rule_set = RuleSet::new(
+        "basic_royalty_enforcement".to_string(),
+        context.payer.pubkey(),
+    );
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), transfer_rule)
+        .unwrap();
+
+    println!("{}", serde_json::to_string_pretty(&rule_set,).unwrap());
+
+    // Put the RuleSet on chain.
+    let rule_set_addr = create_rule_set_on_chain(
+        &mut context,
+        rule_set.clone(),
+        "basic_royalty_enforcement".to_string(),
+    )
+    .await;
+
+    // --------------------------------
+    // Validate wallet to wallet
+    // --------------------------------
+    // Create a Keypairs to simulate wallets.
+    let source_wallet = Keypair::new();
+    let dest_wallet = Keypair::new();
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source_wallet.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(dest_wallet.pubkey()),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source_wallet.pubkey(), false),
+            AccountMeta::new_readonly(dest_wallet.pubkey(), false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate OwnerTransfer operation.
+    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // --------------------------------
+    // Validate wallet to PDA
+    // --------------------------------
+    // Our derived key is going to be an account owned by the
+    // mpl-token-auth-rules program. Any one will do so for convenience
+    // we just use the RuleSet.  These are the RuleSet seeds.
+    let seeds = vec![
+        mpl_token_auth_rules::pda::PREFIX.as_bytes().to_vec(),
+        context.payer.pubkey().as_ref().to_vec(),
+        "basic_royalty_enforcement".as_bytes().to_vec(),
+    ];
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source_wallet.pubkey()),
+        ),
+        (
+            PayloadKey::DestinationSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(seeds.clone())),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source_wallet.pubkey(), false),
+            AccountMeta::new_readonly(rule_set_addr, false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate OwnerTransfer operation.
+    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // --------------------------------
+    // Validate PDA to PDA
+    // --------------------------------
+    // Create a second RuleSet on chain for the sole purpose of having
+    // another PDA that is owned mpl-token-auth-rules program.
+    let second_rule_set = RuleSet::new("second_rule_set".to_string(), context.payer.pubkey());
+
+    let second_rule_set_addr =
+        create_rule_set_on_chain(&mut context, second_rule_set, "second_rule_set".to_string())
+            .await;
+
+    let second_rule_set_seeds = vec![
+        mpl_token_auth_rules::pda::PREFIX.as_bytes().to_vec(),
+        context.payer.pubkey().as_ref().to_vec(),
+        "second_rule_set".as_bytes().to_vec(),
+    ];
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::SourceSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(seeds.clone())),
+        ),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::DestinationSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(second_rule_set_seeds)),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(second_rule_set_addr),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(second_rule_set_addr, false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate OwnerTransfer operation.
+    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // --------------------------------
+    // Validate PDA to wallet
+    // --------------------------------
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::SourceSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(seeds.clone())),
+        ),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(dest_wallet.pubkey()),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(dest_wallet.pubkey(), false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate OwnerTransfer operation.
+    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // --------------------------------
+    // Validate fail unowned PDA
+    // --------------------------------
+    // Create an associated token account for the sole purpose of having
+    // a valid PDA that is owned by a different program than what is in the Rule.
+    create_mint(
+        &mut context,
+        &mint,
+        &source_wallet.pubkey(),
+        Some(&source_wallet.pubkey()),
+        0,
+    )
+    .await
+    .unwrap();
+
+    let associated_token_account =
+        create_associated_token_account(&mut context, &source_wallet, &mint.pubkey())
+            .await
+            .unwrap();
+
+    let associated_token_account_seeds = vec![
+        source_wallet.pubkey().to_bytes().to_vec(),
+        spl_token::ID.to_bytes().to_vec(),
+        mint.to_bytes().to_vec(),
+    ];
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source_wallet.pubkey()),
+        ),
+        (
+            PayloadKey::DestinationSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(associated_token_account_seeds)),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(associated_token_account),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source_wallet.pubkey(), false),
+            AccountMeta::new_readonly(associated_token_account, false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate OwnerTransfer operation.
+    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // Check that error is what we expect.  It should fail the ProgramOwnedList Rule since the
+    // owner is not in the Rule.
+    assert_rule_set_error(err, RuleSetError::ProgramOwnedListCheckFailed);
+
+    // --------------------------------
+    // Validate fail program owned but not PDA
+    // --------------------------------
+    // Create a wallet account owned by this program.
+    let program_owned_account = Keypair::new();
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[system_instruction::create_account(
+            &context.payer.pubkey(),
+            &program_owned_account.pubkey(),
+            rent.minimum_balance(0),
+            0,
+            &mpl_token_auth_rules::ID,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &program_owned_account],
+        context.last_blockhash,
+    );
+
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source_wallet.pubkey()),
+        ),
+        (
+            PayloadKey::DestinationSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(seeds)),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(program_owned_account.pubkey()),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source_wallet.pubkey(), false),
+            AccountMeta::new_readonly(program_owned_account.pubkey(), false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // Check that error is what we expect.  It should fail the PDAMatch Rule after passing
+    // the ProgramOwnedList Rule, since the owner was correct but it is not a valid PDA.
+    assert_rule_set_error(err, RuleSetError::PDAMatchCheckFailed);
+}
+
+#[tokio::test]
+async fn multiple_operations() {
+    let mut context = program_test().start_with_context().await;
+
+    get_primitive_rules!(
+        source_owned_by_sys_program,
+        dest_program_allow_list,
+        dest_pda_match,
+        _source_program_allow_list,
+        _source_pda_match,
+        _dest_owned_by_sys_program,
+    );
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Compose the Owner Transfer rule as follows:
+    // (source is a wallet && dest is on allow list && dest is a PDA)
+    let transfer_rule = Rule::All {
+        rules: vec![
+            source_owned_by_sys_program,
+            dest_program_allow_list,
+            dest_pda_match,
+        ],
+    };
+
+    // Merkle tree root generated in a different test program.
+    let marketplace_tree_root: [u8; 32] = [
+        132, 141, 27, 31, 23, 154, 145, 128, 32, 62, 122, 224, 248, 128, 37, 139, 200, 46, 163,
+        238, 76, 123, 155, 141, 73, 12, 111, 192, 122, 80, 126, 155,
+    ];
+
+    // The provided leaf node must be a member of the marketplace Merkle tree.
+    let leaf_in_marketplace_tree = Rule::PubkeyTreeMatch {
+        root: marketplace_tree_root,
+        field: PayloadKey::Destination.to_string(),
+    };
+
+    // Create RuleSet.
+    let mut rule_set = RuleSet::new(
+        "basic_royalty_enforcement".to_string(),
+        context.payer.pubkey(),
+    );
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), transfer_rule)
+        .unwrap();
+
+    rule_set
+        .add(
+            Operation::Delegate.to_string(),
+            leaf_in_marketplace_tree.clone(),
+        )
+        .unwrap();
+    rule_set
+        .add(
+            Operation::SaleTransfer.to_string(),
+            leaf_in_marketplace_tree,
+        )
+        .unwrap();
+
+    println!("{}", serde_json::to_string_pretty(&rule_set,).unwrap());
+
+    // Put the RuleSet on chain.
+    let rule_set_addr = create_rule_set_on_chain(
+        &mut context,
+        rule_set,
+        "basic_royalty_enforcement".to_string(),
+    )
+    .await;
+
+    // --------------------------------
+    // Validate wallet to PDA
+    // --------------------------------
+    // Create a Keypair to simulate an owner's wallet.
+    let source_wallet = Keypair::new();
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Our derived key is going to be an account owned by the
+    // mpl-token-auth-rules program. Any one will do so for convenience
+    // we just use the RuleSet.  These are the RuleSet seeds.
+    let seeds = vec![
+        mpl_token_auth_rules::pda::PREFIX.as_bytes().to_vec(),
+        context.payer.pubkey().as_ref().to_vec(),
+        "basic_royalty_enforcement".as_bytes().to_vec(),
+    ];
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source_wallet.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::DestinationSeeds.to_string(),
+            PayloadType::Seeds(SeedsVec::new(seeds.clone())),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source_wallet.pubkey(), false),
+            AccountMeta::new_readonly(rule_set_addr, false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate OwnerTransfer operation.
+    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // --------------------------------
+    // Validate fail wallet to wallet.
+    // --------------------------------
+    let dest_wallet = Keypair::new();
+    let payload = Payload::from([
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source_wallet.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(dest_wallet.pubkey()),
+        ),
+    ]);
+
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source_wallet.pubkey(), false),
+            AccountMeta::new_readonly(dest_wallet.pubkey(), false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+
+    // Check that error is what we expect.  The destination wallet is owned by the System Program
+    // so in this case it doesn't match the ProgramOwnedList Rule.
+    assert_rule_set_error(err, RuleSetError::ProgramOwnedListCheckFailed);
 
     // --------------------------------
     // Validate Delegate operation
@@ -277,7 +770,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `Delegate` operation.
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
-        .mint(mint)
+        .mint(mint.pubkey())
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::Delegate.to_string(),
@@ -296,7 +789,7 @@ async fn basic_royalty_enforcement() {
     // Create a `validate` instruction for a `SaleTransfer` operation.
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
-        .mint(mint)
+        .mint(mint.pubkey())
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::SaleTransfer.to_string(),

--- a/program/tests/frequency.rs
+++ b/program/tests/frequency.rs
@@ -32,7 +32,9 @@ async fn test_frequency() {
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -52,7 +54,7 @@ async fn test_frequency() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
         })
@@ -80,7 +82,7 @@ async fn test_frequency() {
         .rule_set_state_pda(rule_set_state_addr)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
         })
@@ -106,7 +108,7 @@ async fn test_frequency() {
         .rule_set_state_pda(rule_set_state_addr)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
         })

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -74,7 +74,7 @@ async fn test_payer_not_signer_fails() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
         })
@@ -136,7 +136,7 @@ async fn test_additional_signer_and_not_amount() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), overall_rule)
+        .add(Operation::OwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -163,7 +163,7 @@ async fn test_additional_signer_and_not_amount() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
         })
@@ -188,7 +188,7 @@ async fn test_additional_signer_and_not_amount() {
             AccountMeta::new_readonly(second_signer.pubkey(), true),
         ])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -213,7 +213,7 @@ async fn test_additional_signer_and_not_amount() {
             AccountMeta::new_readonly(second_signer.pubkey(), true),
         ])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -240,7 +240,7 @@ async fn test_update_ruleset() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), pass_rule)
+        .add(Operation::OwnerTransfer.to_string(), pass_rule)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -268,7 +268,7 @@ async fn test_update_ruleset() {
     // Create a new RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), overall_rule)
+        .add(Operation::OwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     // Put the updated RuleSet on chain.

--- a/program/tests/not.rs
+++ b/program/tests/not.rs
@@ -35,7 +35,7 @@ async fn test_not() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), not_amount_check)
+        .add(Operation::OwnerTransfer.to_string(), not_amount_check)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -59,7 +59,7 @@ async fn test_not() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -84,7 +84,7 @@ async fn test_not() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/pass.rs
+++ b/program/tests/pass.rs
@@ -24,7 +24,7 @@ async fn test_pass() {
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Transfer.to_string(), pass_rule)
+        .add(Operation::OwnerTransfer.to_string(), pass_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -45,7 +45,7 @@ async fn test_pass() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
         })

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -172,7 +172,7 @@ async fn test_pda_match_specified_owner() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .additional_rule_accounts(vec![AccountMeta::new_readonly(invalid_pda, false)])
+        .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::OwnerTransfer.to_string(),
             payload: payload.clone(),
@@ -210,7 +210,7 @@ async fn test_pda_match_specified_owner() {
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
-        .additional_rule_accounts(vec![AccountMeta::new_readonly(rule_set_addr, false)])
+        .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::OwnerTransfer.to_string(),
             payload,

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -32,7 +32,9 @@ async fn test_pda_match_assumed_owner() {
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -74,7 +76,7 @@ async fn test_pda_match_assumed_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(invalid_pda, false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
         })
@@ -108,7 +110,7 @@ async fn test_pda_match_assumed_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(rule_set_addr, false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -135,7 +137,9 @@ async fn test_pda_match_specified_owner() {
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -170,7 +174,7 @@ async fn test_pda_match_specified_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(invalid_pda, false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
         })
@@ -208,7 +212,7 @@ async fn test_pda_match_specified_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(rule_set_addr, false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -33,7 +33,9 @@ async fn program_owned() {
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -66,7 +68,7 @@ async fn program_owned() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -115,7 +117,7 @@ async fn program_owned() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -84,7 +84,7 @@ async fn program_owned() {
     // --------------------------------
     // Validate pass
     // --------------------------------
-    // Create an account owned by this program.
+    // Create an account owned mpl-token-metadata.
     let program_owned_account = Keypair::new();
     let rent = context.banks_client.get_rent().await.unwrap();
     let tx = Transaction::new_signed_with_payer(

--- a/program/tests/pubkey_list_match.rs
+++ b/program/tests/pubkey_list_match.rs
@@ -29,12 +29,14 @@ async fn test_pubkey_list_match() {
 
     let rule = Rule::PubkeyListMatch {
         pubkeys: vec![target_1.pubkey(), target_2.pubkey(), target_3.pubkey()],
-        field: PayloadKey::Holder.to_string(),
+        field: PayloadKey::Authority.to_string(),
     };
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -50,7 +52,7 @@ async fn test_pubkey_list_match() {
 
     // Store the payload of data to validate against the rule definition with WRONG Pubkey.
     let payload = Payload::from([(
-        PayloadKey::Holder.to_string(),
+        PayloadKey::Authority.to_string(),
         PayloadType::Pubkey(Keypair::new().pubkey()),
     )]);
 
@@ -60,7 +62,7 @@ async fn test_pubkey_list_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -81,7 +83,7 @@ async fn test_pubkey_list_match() {
 
     // Store the payload of data to validate against the rule definition with CORRECT Pubkey.
     let payload = Payload::from([(
-        PayloadKey::Holder.to_string(),
+        PayloadKey::Authority.to_string(),
         PayloadType::Pubkey(target_2.pubkey()),
     )]);
 
@@ -91,7 +93,7 @@ async fn test_pubkey_list_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/pubkey_match.rs
+++ b/program/tests/pubkey_match.rs
@@ -32,7 +32,9 @@ async fn test_pubkey_match() {
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -58,7 +60,7 @@ async fn test_pubkey_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -86,7 +88,7 @@ async fn test_pubkey_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/pubkey_tree_match.rs
+++ b/program/tests/pubkey_tree_match.rs
@@ -37,7 +37,9 @@ async fn pubkey_tree_match() {
 
     // Create a RuleSet.
     let mut rule_set = RuleSet::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set.add(Operation::Transfer.to_string(), rule).unwrap();
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), rule)
+        .unwrap();
 
     println!("{:#?}", rule_set);
 
@@ -87,7 +89,7 @@ async fn pubkey_tree_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })
@@ -133,7 +135,7 @@ async fn pubkey_tree_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::Transfer.to_string(),
+            operation: Operation::OwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
         })

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -22,7 +22,7 @@ use solana_sdk::{
 #[repr(C)]
 #[derive(ToPrimitive)]
 pub enum Operation {
-    Transfer,
+    OwnerTransfer,
     Delegate,
     SaleTransfer,
 }
@@ -30,7 +30,7 @@ pub enum Operation {
 impl ToString for Operation {
     fn to_string(&self) -> String {
         match self {
-            Operation::Transfer => "Transfer".to_string(),
+            Operation::OwnerTransfer => "OwnerTransfer".to_string(),
             Operation::Delegate => "Delegate".to_string(),
             Operation::SaleTransfer => "SaleTransfer".to_string(),
         }
@@ -46,12 +46,14 @@ pub enum PayloadKey {
     Authority,
     /// Seeds for a PDA authority of the operation, e.g. when the authority is a PDA.
     AuthoritySeeds,
+    /// The source of the operation, e.g. the owner initiating a transfer.
+    Source,
+    /// Seeds for a PDA source of the operation, e.g. when the source is a PDA.
+    SourceSeeds,
     /// The destination of the operation, e.g. the recipient of a transfer.
     Destination,
-    /// Seeds for a PDA destination of the operation, e.g. when the receipient is a PDA.
+    /// Seeds for a PDA destination of the operation, e.g. when the recipient is a PDA.
     DestinationSeeds,
-    /// The holder of the token, e.g. the sender of a transfer.
-    Holder,
 }
 
 impl ToString for PayloadKey {
@@ -60,9 +62,10 @@ impl ToString for PayloadKey {
             PayloadKey::Amount => "Amount".to_string(),
             PayloadKey::Authority => "Authority".to_string(),
             PayloadKey::AuthoritySeeds => "AuthoritySeeds".to_string(),
+            PayloadKey::Source => "Source".to_string(),
+            PayloadKey::SourceSeeds => "SourceSeeds".to_string(),
             PayloadKey::Destination => "Destination".to_string(),
             PayloadKey::DestinationSeeds => "DestinationSeeds".to_string(),
-            PayloadKey::Holder => "Holder".to_string(),
         }
     }
 }


### PR DESCRIPTION
### Notes
* Adding `ProgramOwnedList` rule.
* Also adding `ProgramOwnedTree` rule but currently it returns `NotImplemented`.
* Changing some of the Payload Key names in tests to more closely match what we expect token-metadata to use.
* Updating Basic Royalty Enforcement tests to have additional example RuleSets.
* Adding BPF tests including tests that check multiple pass and failure cases for the Composed Rules.
* Fixing error rollup that affected the `Any` rule from rolling up the last failed rule error.
* Regenerating SDK.  Note I did not regenerate docs.

### Example Rules in Basic Royalty Enforcement test
**_NOTE ownership by System Program is NOT sufficient to prove an account is a wallet (on-curve) instead of a PDA!_**
#### sys_prog_owned_or_owned_pda_to_sys_prog_owned_or_owned_pda() test:
```
OwnerTransfer:
amount is 1 &&
(source is owned by system program || (source is on allow list && source is a PDA) &&
(dest is owned by system program || (dest is on allow list && dest is a PDA)
```
#### multiple_operations test():
```
OwnerTransfer:
 (source is a owned by system program && dest is on allow list && dest is a PDA)

Delegate:
(The pubkey must be a member of the Merkle tree)

SaleTransfer:
(The pubkey must be a member of the Merkle tree)
(this is a duplicate of what is used for Delegate,
just showing that Rules can be reused for different operations):
```
