### PR TITLE
Adding file, line, and column to test helper functions

### DIFF
--- a/program/tests/additional_signer.rs
+++ b/program/tests/additional_signer.rs
@@ -11,10 +11,7 @@ use mpl_token_auth_rules::{
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation};
 
 #[tokio::test]
 async fn test_additional_signer() {
@@ -61,10 +58,10 @@ async fn test_additional_signer() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::MissingAccount);
+    assert_rule_set_error!(err, RuleSetError::MissingAccount);
 
     // --------------------------------
     // Validate fail not a signer
@@ -83,10 +80,10 @@ async fn test_additional_signer() {
         .instruction();
 
     // Validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::AdditionalSignerCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::AdditionalSignerCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -105,5 +102,5 @@ async fn test_additional_signer() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![&adtl_signer]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![&adtl_signer]).await;
 }

--- a/program/tests/additional_signer.rs
+++ b/program/tests/additional_signer.rs
@@ -11,7 +11,7 @@ use mpl_token_auth_rules::{
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation};
+use utils::{program_test, Operation};
 
 #[tokio::test]
 async fn test_additional_signer() {
@@ -36,7 +36,7 @@ async fn test_additional_signer() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail missing account

--- a/program/tests/all.rs
+++ b/program/tests/all.rs
@@ -11,7 +11,7 @@ use mpl_token_auth_rules::{
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_all() {
@@ -46,7 +46,7 @@ async fn test_all() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/all.rs
+++ b/program/tests/all.rs
@@ -11,10 +11,7 @@ use mpl_token_auth_rules::{
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_all() {
@@ -77,10 +74,10 @@ async fn test_all() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![&second_signer]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![&second_signer]).await;
 
     // Check that error is what we expect.  In this case we expect the first failure to roll up.
-    assert_rule_set_error(err, RuleSetError::AmountCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -105,5 +102,5 @@ async fn test_all() {
         .instruction();
 
     // Validate Transfer operation since both Rule conditions were true.
-    process_passing_validate_ix(&mut context, validate_ix, vec![&second_signer]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![&second_signer]).await;
 }

--- a/program/tests/amount.rs
+++ b/program/tests/amount.rs
@@ -10,7 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_less_than_amount() {
@@ -69,7 +69,7 @@ async fn parametric_amount_check(
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/amount.rs
+++ b/program/tests/amount.rs
@@ -10,10 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_less_than_amount() {
@@ -100,10 +97,10 @@ async fn parametric_amount_check(
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::AmountCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -128,5 +125,5 @@ async fn parametric_amount_check(
         .instruction();
 
     // Validate Transfer operation since because the Amount Rule was NOT'd.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/any.rs
+++ b/program/tests/any.rs
@@ -10,10 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_any() {
@@ -72,10 +69,10 @@ async fn test_any() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.  In this case we expect the last failure to roll up.
-    assert_rule_set_error(err, RuleSetError::AmountCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -97,5 +94,5 @@ async fn test_any() {
         .instruction();
 
     // Validate Transfer operation since at least one Rule condition was true.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/any.rs
+++ b/program/tests/any.rs
@@ -10,7 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_any() {
@@ -44,7 +44,7 @@ async fn test_any() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -15,8 +15,8 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use utils::{
-    assert_rule_set_error, create_associated_token_account, create_mint, create_rule_set_on_chain,
-    process_failing_validate_ix, process_passing_validate_ix, program_test, Operation, PayloadKey,
+    create_associated_token_account, create_mint, create_rule_set_on_chain, program_test,
+    Operation, PayloadKey,
 };
 
 static PROGRAM_ALLOW_LIST: [Pubkey; 1] = [mpl_token_auth_rules::ID];
@@ -173,7 +173,7 @@ async fn wallet_to_pda_or_pda_to_wallet() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate PDA to wallet
@@ -210,7 +210,7 @@ async fn wallet_to_pda_or_pda_to_wallet() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }
 
 #[tokio::test]
@@ -310,7 +310,7 @@ async fn wallet_or_pda_to_wallet_or_pda() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate wallet to PDA
@@ -356,7 +356,7 @@ async fn wallet_or_pda_to_wallet_or_pda() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate PDA to PDA
@@ -411,7 +411,7 @@ async fn wallet_or_pda_to_wallet_or_pda() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate PDA to wallet
@@ -448,7 +448,7 @@ async fn wallet_or_pda_to_wallet_or_pda() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate fail unowned PDA
@@ -508,11 +508,11 @@ async fn wallet_or_pda_to_wallet_or_pda() {
         .instruction();
 
     // Fail to validate OwnerTransfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.  It should fail the ProgramOwnedList Rule since the
     // owner is not in the Rule.
-    assert_rule_set_error(err, RuleSetError::ProgramOwnedListCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
 
     // --------------------------------
     // Validate fail program owned but not PDA
@@ -567,11 +567,11 @@ async fn wallet_or_pda_to_wallet_or_pda() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.  It should fail the PDAMatch Rule after passing
     // the ProgramOwnedList Rule, since the owner was correct but it is not a valid PDA.
-    assert_rule_set_error(err, RuleSetError::PDAMatchCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::PDAMatchCheckFailed);
 }
 
 #[tokio::test]
@@ -694,7 +694,7 @@ async fn multiple_operations() {
         .instruction();
 
     // Validate OwnerTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate fail wallet to wallet.
@@ -727,11 +727,11 @@ async fn multiple_operations() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.  The destination wallet is owned by the System Program
     // so in this case it doesn't match the ProgramOwnedList Rule.
-    assert_rule_set_error(err, RuleSetError::ProgramOwnedListCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
 
     // --------------------------------
     // Validate Delegate operation
@@ -781,7 +781,7 @@ async fn multiple_operations() {
         .instruction();
 
     // Validate Delegate operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // --------------------------------
     // Validate SaleTransfer operation
@@ -800,5 +800,5 @@ async fn multiple_operations() {
         .instruction();
 
     // Validate SaleTransfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -14,10 +14,7 @@ use solana_sdk::{
     instruction::AccountMeta, signature::Signer, signer::keypair::Keypair, system_instruction,
     transaction::Transaction,
 };
-use utils::{
-    create_associated_token_account, create_mint, create_rule_set_on_chain, program_test,
-    Operation, PayloadKey,
-};
+use utils::{create_associated_token_account, create_mint, program_test, Operation, PayloadKey};
 
 static PROGRAM_ALLOW_LIST: [Pubkey; 1] = [mpl_token_auth_rules::ID];
 
@@ -114,10 +111,10 @@ async fn wallet_to_pda_or_pda_to_wallet() {
     println!("{}", serde_json::to_string_pretty(&rule_set,).unwrap());
 
     // Put the RuleSet on chain.
-    let rule_set_addr = create_rule_set_on_chain(
+    let rule_set_addr = create_rule_set_on_chain!(
         &mut context,
         rule_set,
-        "basic_royalty_enforcement".to_string(),
+        "basic_royalty_enforcement".to_string()
     )
     .await;
 
@@ -265,10 +262,10 @@ async fn wallet_or_pda_to_wallet_or_pda() {
     println!("{}", serde_json::to_string_pretty(&rule_set,).unwrap());
 
     // Put the RuleSet on chain.
-    let rule_set_addr = create_rule_set_on_chain(
+    let rule_set_addr = create_rule_set_on_chain!(
         &mut context,
         rule_set.clone(),
-        "basic_royalty_enforcement".to_string(),
+        "basic_royalty_enforcement".to_string()
     )
     .await;
 
@@ -366,7 +363,7 @@ async fn wallet_or_pda_to_wallet_or_pda() {
     let second_rule_set = RuleSet::new("second_rule_set".to_string(), context.payer.pubkey());
 
     let second_rule_set_addr =
-        create_rule_set_on_chain(&mut context, second_rule_set, "second_rule_set".to_string())
+        create_rule_set_on_chain!(&mut context, second_rule_set, "second_rule_set".to_string())
             .await;
 
     let second_rule_set_seeds = vec![
@@ -637,10 +634,10 @@ async fn multiple_operations() {
     println!("{}", serde_json::to_string_pretty(&rule_set,).unwrap());
 
     // Put the RuleSet on chain.
-    let rule_set_addr = create_rule_set_on_chain(
+    let rule_set_addr = create_rule_set_on_chain!(
         &mut context,
         rule_set,
-        "basic_royalty_enforcement".to_string(),
+        "basic_royalty_enforcement".to_string()
     )
     .await;
 

--- a/program/tests/frequency.rs
+++ b/program/tests/frequency.rs
@@ -12,10 +12,7 @@ use mpl_token_auth_rules::{
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_program_error, assert_rule_set_error, create_rule_set_on_chain,
-    process_failing_validate_ix, program_test, Operation,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation};
 
 #[tokio::test]
 async fn test_frequency() {
@@ -62,10 +59,10 @@ async fn test_frequency() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_program_error(err, ProgramError::NotEnoughAccountKeys);
+    assert_program_error!(err, ProgramError::NotEnoughAccountKeys);
 
     // --------------------------------
     // Validate wrong authority
@@ -90,10 +87,10 @@ async fn test_frequency() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::RuleAuthorityIsNotSigner);
+    assert_rule_set_error!(err, RuleSetError::RuleAuthorityIsNotSigner);
 
     // --------------------------------
     // Validate not implemented
@@ -116,8 +113,8 @@ async fn test_frequency() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![&rule_authority]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![&rule_authority]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::NotImplemented);
+    assert_rule_set_error!(err, RuleSetError::NotImplemented);
 }

--- a/program/tests/frequency.rs
+++ b/program/tests/frequency.rs
@@ -12,7 +12,7 @@ use mpl_token_auth_rules::{
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation};
+use utils::{program_test, Operation};
 
 #[tokio::test]
 async fn test_frequency() {
@@ -37,7 +37,7 @@ async fn test_frequency() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate missing accounts

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -18,10 +18,7 @@ use solana_sdk::{
     signer::keypair::Keypair,
     transaction::{Transaction, TransactionError},
 };
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_payer_not_signer_fails() {
@@ -171,10 +168,10 @@ async fn test_additional_signer_and_not_amount() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::MissingAccount);
+    assert_rule_set_error!(err, RuleSetError::MissingAccount);
 
     // --------------------------------
     // Validate pass
@@ -196,7 +193,7 @@ async fn test_additional_signer_and_not_amount() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![&second_signer]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![&second_signer]).await;
 
     // --------------------------------
     // Validate fail wrong amount
@@ -221,10 +218,10 @@ async fn test_additional_signer_and_not_amount() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![&second_signer]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![&second_signer]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::AmountCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
 }
 
 #[tokio::test]

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -18,7 +18,7 @@ use solana_sdk::{
     signer::keypair::Keypair,
     transaction::{Transaction, TransactionError},
 };
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_payer_not_signer_fails() {
@@ -140,7 +140,7 @@ async fn test_additional_signer_and_not_amount() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail missing account
@@ -242,7 +242,7 @@ async fn test_update_ruleset() {
 
     // Put the RuleSet on chain.
     let _rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Update RuleSet
@@ -270,5 +270,5 @@ async fn test_update_ruleset() {
 
     // Put the updated RuleSet on chain.
     let _rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 }

--- a/program/tests/not.rs
+++ b/program/tests/not.rs
@@ -10,7 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_not() {
@@ -39,7 +39,7 @@ async fn test_not() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/not.rs
+++ b/program/tests/not.rs
@@ -10,10 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_not() {
@@ -67,10 +64,10 @@ async fn test_not() {
         .instruction();
 
     // Fail to validate Transfer operation because the Amount Rule was NOT'd.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::AmountCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -92,5 +89,5 @@ async fn test_not() {
         .instruction();
 
     // Validate Transfer operation since because the Amount Rule was NOT'd.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/pass.rs
+++ b/program/tests/pass.rs
@@ -9,7 +9,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation};
+use utils::{program_test, Operation};
 
 #[tokio::test]
 async fn test_pass() {
@@ -31,7 +31,7 @@ async fn test_pass() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate pass

--- a/program/tests/pass.rs
+++ b/program/tests/pass.rs
@@ -9,7 +9,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, process_passing_validate_ix, program_test, Operation};
+use utils::{create_rule_set_on_chain, program_test, Operation};
 
 #[tokio::test]
 async fn test_pass() {
@@ -53,5 +53,5 @@ async fn test_pass() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -11,10 +11,7 @@ use mpl_token_auth_rules::{
 use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_pda_match_assumed_owner() {
@@ -84,10 +81,10 @@ async fn test_pda_match_assumed_owner() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::PDAMatchCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::PDAMatchCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -118,7 +115,7 @@ async fn test_pda_match_assumed_owner() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }
 
 #[tokio::test]
@@ -182,10 +179,10 @@ async fn test_pda_match_specified_owner() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::PDAMatchCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::PDAMatchCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -220,5 +217,5 @@ async fn test_pda_match_specified_owner() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -11,7 +11,7 @@ use mpl_token_auth_rules::{
 use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_pda_match_assumed_owner() {
@@ -37,7 +37,7 @@ async fn test_pda_match_assumed_owner() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail
@@ -142,7 +142,7 @@ async fn test_pda_match_specified_owner() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -13,10 +13,7 @@ use solana_sdk::{
     instruction::AccountMeta, signature::Signer, signer::keypair::Keypair, system_instruction,
     transaction::Transaction,
 };
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn program_owned() {
@@ -76,10 +73,10 @@ async fn program_owned() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::ProgramOwnedCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::ProgramOwnedCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -125,5 +122,5 @@ async fn program_owned() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
     instruction::AccountMeta, signature::Signer, signer::keypair::Keypair, system_instruction,
     transaction::Transaction,
 };
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn program_owned() {
@@ -38,7 +38,7 @@ async fn program_owned() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/pubkey_list_match.rs
+++ b/program/tests/pubkey_list_match.rs
@@ -10,10 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_pubkey_list_match() {
@@ -70,10 +67,10 @@ async fn test_pubkey_list_match() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::PubkeyListMatchCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::PubkeyListMatchCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -101,5 +98,5 @@ async fn test_pubkey_list_match() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/pubkey_list_match.rs
+++ b/program/tests/pubkey_list_match.rs
@@ -10,7 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_pubkey_list_match() {
@@ -39,7 +39,7 @@ async fn test_pubkey_list_match() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/pubkey_match.rs
+++ b/program/tests/pubkey_match.rs
@@ -10,10 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_pubkey_match() {
@@ -68,10 +65,10 @@ async fn test_pubkey_match() {
         .instruction();
 
     // Fail to validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::PubkeyMatchCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::PubkeyMatchCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -96,5 +93,5 @@ async fn test_pubkey_match() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/pubkey_match.rs
+++ b/program/tests/pubkey_match.rs
@@ -10,7 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn test_pubkey_match() {
@@ -37,7 +37,7 @@ async fn test_pubkey_match() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/pubkey_tree_match.rs
+++ b/program/tests/pubkey_tree_match.rs
@@ -10,10 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{
-    assert_rule_set_error, create_rule_set_on_chain, process_failing_validate_ix,
-    process_passing_validate_ix, program_test, Operation, PayloadKey,
-};
+use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn pubkey_tree_match() {
@@ -97,10 +94,10 @@ async fn pubkey_tree_match() {
         .instruction();
 
     // Validate Transfer operation.
-    let err = process_failing_validate_ix(&mut context, validate_ix, vec![]).await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![]).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error(err, RuleSetError::PubkeyTreeMatchCheckFailed);
+    assert_rule_set_error!(err, RuleSetError::PubkeyTreeMatchCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -143,5 +140,5 @@ async fn pubkey_tree_match() {
         .instruction();
 
     // Validate Transfer operation.
-    process_passing_validate_ix(&mut context, validate_ix, vec![]).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![]).await;
 }

--- a/program/tests/pubkey_tree_match.rs
+++ b/program/tests/pubkey_tree_match.rs
@@ -10,7 +10,7 @@ use mpl_token_auth_rules::{
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
-use utils::{create_rule_set_on_chain, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 async fn pubkey_tree_match() {
@@ -42,7 +42,7 @@ async fn pubkey_tree_match() {
 
     // Put the RuleSet on chain.
     let rule_set_addr =
-        create_rule_set_on_chain(&mut context, rule_set, "test rule_set".to_string()).await;
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // --------------------------------
     // Validate fail

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -119,10 +119,27 @@ pub async fn create_rule_set_on_chain(
     rule_set_addr
 }
 
-pub async fn process_passing_validate_ix(
+#[macro_export]
+macro_rules! process_passing_validate_ix {
+    ($context:expr, $validate_ix:expr, $additional_signers:expr) => {
+        $crate::utils::process_passing_validate_ix_with_loc(
+            $context,
+            $validate_ix,
+            $additional_signers,
+            file!(),
+            line!(),
+            column!(),
+        )
+    };
+}
+
+pub async fn process_passing_validate_ix_with_loc(
     context: &mut ProgramTestContext,
     validate_ix: Instruction,
     additional_signers: Vec<&Keypair>,
+    file: &str,
+    line: u32,
+    column: u32,
 ) {
     let mut signing_keypairs = vec![&context.payer];
     signing_keypairs.extend(additional_signers);
@@ -140,13 +157,35 @@ pub async fn process_passing_validate_ix(
         .banks_client
         .process_transaction(validate_tx)
         .await
-        .expect("Validation should succeed");
+        .unwrap_or_else(|_| {
+            panic!(
+                "Validation should succeed, process_passing_validate_ix called at {}:{}:{}",
+                file, line, column
+            )
+        });
 }
 
-pub async fn process_failing_validate_ix(
+#[macro_export]
+macro_rules! process_failing_validate_ix {
+    ($context:expr, $validate_ix:expr, $additional_signers:expr) => {
+        $crate::utils::process_failing_validate_ix_with_loc(
+            $context,
+            $validate_ix,
+            $additional_signers,
+            file!(),
+            line!(),
+            column!(),
+        )
+    };
+}
+
+pub async fn process_failing_validate_ix_with_loc(
     context: &mut ProgramTestContext,
     validate_ix: Instruction,
     additional_signers: Vec<&Keypair>,
+    file: &str,
+    line: u32,
+    column: u32,
 ) -> BanksClientError {
     let mut signing_keypairs = vec![&context.payer];
     signing_keypairs.extend(additional_signers);
@@ -164,10 +203,36 @@ pub async fn process_failing_validate_ix(
         .banks_client
         .process_transaction(validate_tx)
         .await
-        .expect_err("validation should fail")
+        .expect_err(&format!(
+            "validation should fail, process_failing_validate_ix called at {}:{}:{}",
+            file, line, column
+        ))
 }
 
-pub fn assert_rule_set_error(err: BanksClientError, rule_set_error: RuleSetError) {
+#[macro_export]
+macro_rules! assert_rule_set_error {
+    ($err:path, $rule_set_error:path) => {
+        $crate::utils::assert_rule_set_error_with_loc(
+            $err,
+            $rule_set_error,
+            file!(),
+            line!(),
+            column!(),
+        );
+    };
+}
+
+pub fn assert_rule_set_error_with_loc(
+    err: BanksClientError,
+    rule_set_error: RuleSetError,
+    file: &str,
+    line: u32,
+    column: u32,
+) {
+    let calling_location = format!(
+        "assert_rule_set_error called at {}:{}:{}",
+        file, line, column
+    );
     // Deconstruct the error code and make sure it is what we expect.
     match err {
         BanksClientError::TransactionError(TransactionError::InstructionError(
@@ -175,23 +240,50 @@ pub fn assert_rule_set_error(err: BanksClientError, rule_set_error: RuleSetError
             InstructionError::Custom(val),
         )) => {
             let deconstructed_err = RuleSetError::from_u32(val).unwrap();
-            assert_eq!(deconstructed_err, rule_set_error);
+            assert_eq!(deconstructed_err, rule_set_error, "{}", calling_location);
         }
-        _ => panic!("Unexpected error {:?}", err),
+        _ => panic!("Unexpected error {:?}, {}", err, calling_location),
     }
 }
 
-pub fn assert_program_error(err: BanksClientError, program_error: ProgramError) {
+#[macro_export]
+macro_rules! assert_program_error {
+    ($err:path, $rule_set_error:path) => {
+        $crate::utils::assert_program_error_with_loc(
+            $err,
+            $rule_set_error,
+            file!(),
+            line!(),
+            column!(),
+        )
+    };
+}
+
+pub fn assert_program_error_with_loc(
+    err: BanksClientError,
+    program_error: ProgramError,
+    file: &str,
+    line: u32,
+    column: u32,
+) {
+    let calling_location = format!(
+        "assert_program_error called at {}:{}:{}",
+        file, line, column
+    );
     // Deconstruct the error code and make sure it is what we expect.
     match err {
         BanksClientError::TransactionError(TransactionError::InstructionError(_, err)) => {
             assert_eq!(
-                ProgramError::try_from(err)
-                    .expect("Could not convert InstructionError to ProgramError"),
-                program_error
+                ProgramError::try_from(err).unwrap_or_else(|_| panic!(
+                    "Could not convert InstructionError to ProgramError at {}",
+                    calling_location,
+                )),
+                program_error,
+                "{}",
+                calling_location,
             );
         }
-        _ => panic!("Unexpected error {:?}", err),
+        _ => panic!("Unexpected error {:?}, {}", err, calling_location),
     }
 }
 


### PR DESCRIPTION
### Notes
* Convert several test helper functions to macros which still have the original functionality, but insert a message showing where they were called from.
* This makes it easier to debug BPF tests, i.e., so that an assertion failure doesn't just show up as the helper function's file and line number.

### Example
```
thread 'wallet_or_pda_to_wallet_or_pda' panicked at 'assertion failed: `(left == right)`
  left: `ProgramOwnedListCheckFailed`,
 right: `PDAMatchCheckFailed`: assert_rule_set_error called at tests/basic_royalty_enforcement.rs:574:5', tests/utils/mod.rs:201:13
```
The new part is: `assert_rule_set_error called at tests/basic_royalty_enforcement.rs:574:5`,
Instead of it only showing: `tests/utils/mod.rs:201:13`.