### PR TITLE
BPF general testing updates

### DIFF
--- a/program/tests/additional_signer.rs
+++ b/program/tests/additional_signer.rs
@@ -62,7 +62,7 @@ async fn test_additional_signer() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::MissingAccount);
+    assert_custom_error!(err, RuleSetError::MissingAccount);
 
     // --------------------------------
     // Validate fail not a signer
@@ -85,7 +85,7 @@ async fn test_additional_signer() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::AdditionalSignerCheckFailed);
+    assert_custom_error!(err, RuleSetError::AdditionalSignerCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/all.rs
+++ b/program/tests/all.rs
@@ -79,7 +79,7 @@ async fn test_all() {
         process_failing_validate_ix!(&mut context, validate_ix, vec![&second_signer], None).await;
 
     // Check that error is what we expect.  In this case we expect the first failure to roll up.
-    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/amount.rs
+++ b/program/tests/amount.rs
@@ -101,7 +101,7 @@ async fn parametric_amount_check(
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/any.rs
+++ b/program/tests/any.rs
@@ -73,7 +73,7 @@ async fn test_any() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.  In this case we expect the last failure to roll up.
-    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -153,7 +153,7 @@ async fn sys_prog_owned_or_owned_pda_to_sys_prog_owned_or_owned_pda() {
 
     // Check that error is what we expect.  It should fail the ProgramOwnedList Rule since the
     // owner is not in the Rule.
-    assert_rule_set_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
+    assert_custom_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
 
     // --------------------------------
     // Validate wallet to prog owned PDA
@@ -338,7 +338,7 @@ async fn sys_prog_owned_or_owned_pda_to_sys_prog_owned_or_owned_pda() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate fail valid PDA, but not prog owned
@@ -404,7 +404,7 @@ async fn sys_prog_owned_or_owned_pda_to_sys_prog_owned_or_owned_pda() {
 
     // Check that error is what we expect.  It should fail the ProgramOwnedList Rule since the
     // owner is not in the Rule.
-    assert_rule_set_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
+    assert_custom_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
 
     // --------------------------------
     // Validate fail prog owned but not a PDA
@@ -465,7 +465,7 @@ async fn sys_prog_owned_or_owned_pda_to_sys_prog_owned_or_owned_pda() {
 
     // Check that error is what we expect.  It should fail the PDAMatch Rule after passing
     // the ProgramOwnedList Rule, since the owner was correct but it is not a valid PDA.
-    assert_rule_set_error!(err, RuleSetError::PDAMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PDAMatchCheckFailed);
 }
 
 #[tokio::test]
@@ -622,7 +622,7 @@ async fn multiple_operations() {
 
     // Check that error is what we expect.  The destination is owned by the System Program
     // so in this case it doesn't match the ProgramOwnedList Rule.
-    assert_rule_set_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
+    assert_custom_error!(err, RuleSetError::ProgramOwnedListCheckFailed);
 
     // --------------------------------
     // Validate Delegate operation

--- a/program/tests/buffered_rule_set.rs
+++ b/program/tests/buffered_rule_set.rs
@@ -94,7 +94,7 @@ async fn buffered_rule_set() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::PubkeyListMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PubkeyListMatchCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -179,7 +179,7 @@ async fn test_composed_rule() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::MissingAccount);
+    assert_custom_error!(err, RuleSetError::MissingAccount);
 
     // --------------------------------
     // Validate pass
@@ -232,7 +232,7 @@ async fn test_composed_rule() {
         process_failing_validate_ix!(&mut context, validate_ix, vec![&second_signer], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 }
 
 #[tokio::test]

--- a/program/tests/not.rs
+++ b/program/tests/not.rs
@@ -68,7 +68,7 @@ async fn test_not() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::AmountCheckFailed);
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -85,7 +85,7 @@ async fn test_pda_match_assumed_owner() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::PDAMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PDAMatchCheckFailed);
 
     // --------------------------------
     // Validate pass
@@ -185,7 +185,7 @@ async fn test_pda_match_specified_owner() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::PDAMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PDAMatchCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -77,7 +77,7 @@ async fn program_owned() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::ProgramOwnedCheckFailed);
+    assert_custom_error!(err, RuleSetError::ProgramOwnedCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/program_owned_tree_match.rs
+++ b/program/tests/program_owned_tree_match.rs
@@ -108,7 +108,7 @@ async fn program_owned_tree_match() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::ProgramOwnedTreeCheckFailed);
+    assert_custom_error!(err, RuleSetError::ProgramOwnedTreeCheckFailed);
 
     // --------------------------------
     // Validate fail correct owner, incorrect proof
@@ -191,7 +191,7 @@ async fn program_owned_tree_match() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::ProgramOwnedTreeCheckFailed);
+    assert_custom_error!(err, RuleSetError::ProgramOwnedTreeCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/pubkey_list_match.rs
+++ b/program/tests/pubkey_list_match.rs
@@ -71,7 +71,7 @@ async fn test_pubkey_list_match() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::PubkeyListMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PubkeyListMatchCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/pubkey_match.rs
+++ b/program/tests/pubkey_match.rs
@@ -69,7 +69,7 @@ async fn test_pubkey_match() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::PubkeyMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PubkeyMatchCheckFailed);
 
     // --------------------------------
     // Validate pass

--- a/program/tests/pubkey_tree_match.rs
+++ b/program/tests/pubkey_tree_match.rs
@@ -106,7 +106,7 @@ async fn pubkey_tree_match() {
     let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.
-    assert_rule_set_error!(err, RuleSetError::PubkeyTreeMatchCheckFailed);
+    assert_custom_error!(err, RuleSetError::PubkeyTreeMatchCheckFailed);
 
     // --------------------------------
     // Validate pass


### PR DESCRIPTION
### Two kind of basic test changes
1. Use assert_custom_error from token-metadata utils but add location
    1. Prior to this had `assert_rule_set_error` and `assert_program_error` that interestingly I created completely separately from `assert_custom_error`, but the problem with `using assert_rule_set error` was that it could miscategorize other program errors for `RuleSetErrors`.
    2. Instead I imported `assert_custom_error` from token-metadata and also found its  more flexible.  I just added the `file!()`, `line1()`, and `column!()` indicators and fully qualified the type paths so that the macro doesn't require other dependencies when calling it.
2. Replace payer not signer test with one that makes more sense.
    1. The previous test just was trying to do unsigned transactions so the payer wasn't a signer and I don't think it could just run the transaction for free.
    2. The new test expects an "other_payer" to be present and is expected to panic if only the banks client context payer signs.  I think this is a more realistic situation.
    3. I wanted to try to validate the processor check on if the payer is a signer, but practically I do not think I can do that when using Shank and the instruction builder.  