### PR TITLE
Modifying `RuleSet` update test and adding new tests

### DIFF
--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -481,7 +481,7 @@
     },
     {
       "code": 23,
-      "name": "RuleSetRevNotAvailable",
+      "name": "RuleSetRevisionNotAvailable",
       "msg": "RuleSet revision not available"
     },
     {

--- a/packages/sdk/src/generated/errors/index.ts
+++ b/packages/sdk/src/generated/errors/index.ts
@@ -496,24 +496,27 @@ createErrorFromNameLookup.set(
 );
 
 /**
- * RuleSetRevNotAvailable: 'RuleSet revision not available'
+ * RuleSetRevisionNotAvailable: 'RuleSet revision not available'
  *
  * @category Errors
  * @category generated
  */
-export class RuleSetRevNotAvailableError extends Error {
+export class RuleSetRevisionNotAvailableError extends Error {
   readonly code: number = 0x17;
-  readonly name: string = 'RuleSetRevNotAvailable';
+  readonly name: string = 'RuleSetRevisionNotAvailable';
   constructor() {
     super('RuleSet revision not available');
     if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, RuleSetRevNotAvailableError);
+      Error.captureStackTrace(this, RuleSetRevisionNotAvailableError);
     }
   }
 }
 
-createErrorFromCodeLookup.set(0x17, () => new RuleSetRevNotAvailableError());
-createErrorFromNameLookup.set('RuleSetRevNotAvailable', () => new RuleSetRevNotAvailableError());
+createErrorFromCodeLookup.set(0x17, () => new RuleSetRevisionNotAvailableError());
+createErrorFromNameLookup.set(
+  'RuleSetRevisionNotAvailable',
+  () => new RuleSetRevisionNotAvailableError(),
+);
 
 /**
  * AdditionalSignerCheckFailed: 'Additional Signer check failed'

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -104,7 +104,7 @@ pub enum RuleSetError {
 
     /// 23 - RuleSet revision not available
     #[error("RuleSet revision not available")]
-    RuleSetRevNotAvailable,
+    RuleSetRevisionNotAvailable,
 
     /// 24 - Additional Signer check failed
     #[error("Additional Signer check failed")]

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -162,7 +162,7 @@ fn create_or_update_v1(
     let new_pda_data_len = revision_map
         .rule_set_revisions
         .last()
-        .ok_or(RuleSetError::RuleSetRevNotAvailable)?
+        .ok_or(RuleSetError::RuleSetRevisionNotAvailable)?
         .checked_add(2)
         .and_then(|len| len.checked_add(serialized_rev_map.len()))
         .and_then(|len| len.checked_add(new_rule_set_data_len))
@@ -196,7 +196,7 @@ fn create_or_update_v1(
                 *revision_map
                     .rule_set_revisions
                     .last()
-                    .ok_or(RuleSetError::RuleSetRevNotAvailable)?,
+                    .ok_or(RuleSetError::RuleSetRevisionNotAvailable)?,
                 &serialized_rev_map,
                 &account_info.data.borrow(),
             )?;
@@ -207,7 +207,7 @@ fn create_or_update_v1(
                 *revision_map
                     .rule_set_revisions
                     .last()
-                    .ok_or(RuleSetError::RuleSetRevNotAvailable)?,
+                    .ok_or(RuleSetError::RuleSetRevisionNotAvailable)?,
                 &serialized_rev_map,
                 &serialized_rule_set,
             )?;
@@ -272,7 +272,7 @@ fn validate_v1(program_id: &Pubkey, ctx: Context<Validate>, args: ValidateArgs) 
             let start = revision_map
                 .rule_set_revisions
                 .get(revision)
-                .ok_or(RuleSetError::RuleSetRevNotAvailable)?;
+                .ok_or(RuleSetError::RuleSetRevisionNotAvailable)?;
 
             let end_index = revision
                 .checked_add(1)
@@ -288,7 +288,7 @@ fn validate_v1(program_id: &Pubkey, ctx: Context<Validate>, args: ValidateArgs) 
             let start = revision_map
                 .rule_set_revisions
                 .last()
-                .ok_or(RuleSetError::RuleSetRevNotAvailable)?;
+                .ok_or(RuleSetError::RuleSetRevisionNotAvailable)?;
             (*start, rev_map_location)
         }
     };

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -2,7 +2,6 @@
 
 pub mod utils;
 
-use borsh::BorshSerialize;
 use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{
@@ -10,17 +9,14 @@ use mpl_token_auth_rules::{
         CreateOrUpdateArgs, InstructionBuilder, ValidateArgs,
     },
     payload::{Payload, PayloadType},
-    state::{
-        CompareOp, Rule, RuleSetHeader, RuleSetRevisionMapV1, RuleSetV1, RULE_SET_LIB_VERSION,
-        RULE_SET_REV_MAP_VERSION, RULE_SET_SERIALIZED_HEADER_LEN,
-    },
+    state::{CompareOp, Rule, RuleSetV1},
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair, transaction::Transaction};
-use utils::{cmp_slice, program_test, Operation, PayloadKey};
+use utils::{program_test, Operation, PayloadKey};
 
 #[tokio::test]
 #[should_panic]
@@ -205,161 +201,4 @@ async fn test_composed_rule() {
 
     // Check that error is what we expect.
     assert_custom_error!(err, RuleSetError::AmountCheckFailed);
-}
-
-#[tokio::test]
-async fn test_update_ruleset() {
-    let mut context = program_test().start_with_context().await;
-
-    // --------------------------------
-    // Create RuleSet
-    // --------------------------------
-    // Create a Pass Rule.
-    let pass_rule = Rule::Pass;
-
-    // Create a RuleSet.
-    let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
-    first_rule_set
-        .add(Operation::OwnerTransfer.to_string(), pass_rule)
-        .unwrap();
-
-    // Put the RuleSet on chain.
-    let _rule_set_addr = create_rule_set_on_chain!(
-        &mut context,
-        first_rule_set.clone(),
-        "test rule_set".to_string()
-    )
-    .await;
-
-    // --------------------------------
-    // Update RuleSet
-    // --------------------------------
-    // Create some other rules.
-    let adtl_signer = Rule::AdditionalSigner {
-        account: context.payer.pubkey(),
-    };
-
-    let amount_check = Rule::Amount {
-        amount: 1,
-        operator: CompareOp::Eq,
-        field: PayloadKey::Amount.to_string(),
-    };
-
-    let overall_rule = Rule::All {
-        rules: vec![adtl_signer, amount_check],
-    };
-
-    // Create a new RuleSet.
-    let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
-    second_rule_set
-        .add(Operation::OwnerTransfer.to_string(), overall_rule)
-        .unwrap();
-
-    // Put the updated RuleSet on chain.
-    let rule_set_addr = create_rule_set_on_chain!(
-        &mut context,
-        second_rule_set.clone(),
-        "test rule_set".to_string()
-    )
-    .await;
-
-    // --------------------------------
-    // Validate the on chain data
-    // --------------------------------
-    // Get the `RuleSet` PDA data.
-    let data = context
-        .banks_client
-        .get_account(rule_set_addr)
-        .await
-        .unwrap()
-        .unwrap()
-        .data;
-
-    // Check the first `RuleSet` lib version.
-    let first_rule_set_version_loc = RULE_SET_SERIALIZED_HEADER_LEN;
-    assert_eq!(
-        data[first_rule_set_version_loc], RULE_SET_LIB_VERSION,
-        "The buffer doesn't match the first rule set's lib version"
-    );
-
-    // Serialize the first `RuleSet` using RMP serde.
-    let mut serialized_first_rule_set = Vec::new();
-    first_rule_set
-        .serialize(&mut Serializer::new(&mut serialized_first_rule_set))
-        .unwrap();
-
-    // Check the first `RuleSet` serialized data.
-    let first_rule_set_start = first_rule_set_version_loc + 1;
-    let first_rule_set_end = first_rule_set_start + serialized_first_rule_set.len();
-    assert!(
-        cmp_slice(
-            &data[first_rule_set_start..first_rule_set_end],
-            &serialized_first_rule_set
-        ),
-        "The buffer doesn't match the serialized first rule set.",
-    );
-
-    // Check the second `RuleSet` lib version.
-    let second_rule_set_version_loc = first_rule_set_end;
-    assert_eq!(
-        data[second_rule_set_version_loc], RULE_SET_LIB_VERSION,
-        "The buffer doesn't match the second rule set's lib version"
-    );
-
-    // Serialize the second `RuleSet` using RMP serde.
-    let mut serialized_second_rule_set = Vec::new();
-    second_rule_set
-        .serialize(&mut Serializer::new(&mut serialized_second_rule_set))
-        .unwrap();
-
-    // Check the second `RuleSet` serialized data.
-    let second_rule_set_start = second_rule_set_version_loc + 1;
-    let second_rule_set_end = second_rule_set_start + serialized_second_rule_set.len();
-    assert!(
-        cmp_slice(
-            &data[second_rule_set_start..second_rule_set_end],
-            &serialized_second_rule_set
-        ),
-        "The buffer doesn't match the serialized second rule set.",
-    );
-
-    // Check the revision map version.
-    let rev_map_version_loc = second_rule_set_end;
-    assert_eq!(
-        data[rev_map_version_loc], RULE_SET_REV_MAP_VERSION,
-        "The buffer doesn't match the revision map version"
-    );
-
-    // Create revision map using the known locations of the two `RuleSet`s in this test.
-    let mut revision_map = RuleSetRevisionMapV1::default();
-    revision_map
-        .rule_set_revisions
-        .push(first_rule_set_version_loc);
-    revision_map
-        .rule_set_revisions
-        .push(second_rule_set_version_loc);
-
-    // Borsh serialize the revision map.
-    let mut serialized_rev_map = Vec::new();
-    revision_map.serialize(&mut serialized_rev_map).unwrap();
-
-    // Check the revision map.
-    let rev_map_start = rev_map_version_loc + 1;
-    assert!(
-        cmp_slice(&data[rev_map_start..], &serialized_rev_map),
-        "The buffer doesn't match the serialized revision map.",
-    );
-
-    // Create header using the known location of the revision map version location.
-    let header = RuleSetHeader::new(rev_map_version_loc);
-
-    // Borsh serialize the header.
-    let mut serialized_header = Vec::new();
-    header.serialize(&mut serialized_header).unwrap();
-
-    // Check the header.
-    assert!(
-        cmp_slice(&data[..RULE_SET_SERIALIZED_HEADER_LEN], &serialized_header),
-        "The buffer doesn't match the serialized header.",
-    );
 }

--- a/program/tests/updated_rule_set.rs
+++ b/program/tests/updated_rule_set.rs
@@ -1,0 +1,515 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod utils;
+
+use borsh::BorshSerialize;
+use mpl_token_auth_rules::{
+    error::RuleSetError,
+    instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
+    payload::{Payload, PayloadType},
+    state::{
+        CompareOp, Rule, RuleSetHeader, RuleSetRevisionMapV1, RuleSetV1, RULE_SET_LIB_VERSION,
+        RULE_SET_REV_MAP_VERSION, RULE_SET_SERIALIZED_HEADER_LEN,
+    },
+};
+use rmp_serde::Serializer;
+use serde::Serialize;
+use solana_program::instruction::AccountMeta;
+use solana_program_test::tokio;
+use solana_sdk::{signature::Signer, signer::keypair::Keypair};
+use utils::{cmp_slice, program_test, Operation, PayloadKey};
+
+#[tokio::test]
+async fn test_update_ruleset_data_integrity() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet 0
+    // --------------------------------
+    let mut rule_sets = vec![];
+
+    // Create a Pass Rule as the overall rule.
+    let first_overall_rule = Rule::Pass;
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(
+            Operation::OwnerTransfer.to_string(),
+            first_overall_rule.clone(),
+        )
+        .unwrap();
+
+    // Save RuleSet for validation later.
+    rule_sets.push(rule_set.clone());
+
+    // Put the RuleSet on chain.
+    let _rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Move forward to avoid duplicate transactions if RuleSets are same.
+    let mut slot = 3;
+    context.warp_to_slot(slot).unwrap();
+    slot += 1;
+
+    // --------------------------------
+    // Create RuleSet 1 and update on chain
+    // --------------------------------
+    // Create some other rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    let amount_check = Rule::Amount {
+        amount: 1,
+        operator: CompareOp::Eq,
+        field: PayloadKey::Amount.to_string(),
+    };
+
+    let second_overall_rule = Rule::All {
+        rules: vec![adtl_signer, amount_check],
+    };
+
+    // Create a new RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::Delegate.to_string(), second_overall_rule.clone())
+        .unwrap();
+
+    rule_set
+        .add(
+            Operation::SaleTransfer.to_string(),
+            second_overall_rule.clone(),
+        )
+        .unwrap();
+
+    // Save RuleSet for validation later.
+    rule_sets.push(rule_set.clone());
+
+    // Put the updated RuleSet on chain.
+    let _rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Move forward to avoid duplicate transactions if RuleSets are same.
+    context.warp_to_slot(slot).unwrap();
+    slot += 1;
+
+    // --------------------------------
+    // Create RuleSet 2 and update on chain
+    // --------------------------------
+    let program_owned = Rule::ProgramOwned {
+        program: mpl_token_metadata::id(),
+        field: PayloadKey::Destination.to_string(),
+    };
+
+    let target_1 = Keypair::new();
+    let target_2 = Keypair::new();
+    let target_3 = Keypair::new();
+
+    let list_match = Rule::PubkeyListMatch {
+        pubkeys: vec![target_1.pubkey(), target_2.pubkey(), target_3.pubkey()],
+        field: PayloadKey::Authority.to_string(),
+    };
+
+    let third_overall_rule = Rule::Any {
+        rules: vec![program_owned, list_match],
+    };
+
+    // Create a new RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(
+            Operation::OwnerTransfer.to_string(),
+            third_overall_rule.clone(),
+        )
+        .unwrap();
+
+    // Save RuleSet for validation later.
+    rule_sets.push(rule_set.clone());
+
+    // Put the updated RuleSet on chain.
+    let _rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Move forward to avoid duplicate transactions if RuleSets are same.
+    context.warp_to_slot(slot).unwrap();
+    slot += 1;
+
+    // --------------------------------
+    // Create RuleSet 3 and update on chain
+    // --------------------------------
+    // Create a new RuleSet reusing some previous rules.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), first_overall_rule)
+        .unwrap();
+    rule_set
+        .add(Operation::Delegate.to_string(), second_overall_rule.clone())
+        .unwrap();
+    rule_set
+        .add(Operation::SaleTransfer.to_string(), second_overall_rule)
+        .unwrap();
+
+    // Save RuleSet for validation later.
+    rule_sets.push(rule_set.clone());
+
+    // Put the updated RuleSet on chain.
+    let _rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Move forward to avoid duplicate transactions if RuleSets are same.
+    context.warp_to_slot(slot).unwrap();
+    slot += 1;
+
+    // --------------------------------
+    // Create RuleSet 4 and update on chain
+    // --------------------------------
+    // Create a new RuleSet reusing some previous rules.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), third_overall_rule)
+        .unwrap();
+
+    // Save RuleSet for validation later.
+    rule_sets.push(rule_set.clone());
+
+    // Put the updated RuleSet on chain.
+    let rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Move forward to avoid duplicate transactions if RuleSets are same.
+    context.warp_to_slot(slot).unwrap();
+
+    // --------------------------------
+    // Validate the on chain data for all RuleSets
+    // --------------------------------
+    // Get the `RuleSet` PDA data.
+    let data = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+
+    // Check all the RuleSets, saving their start locations for later use.
+    let mut offsets = vec![RULE_SET_SERIALIZED_HEADER_LEN];
+    for n in 0..rule_sets.len() {
+        // Offset n is the `RuleSet` lib version location.
+        let rule_set_version_loc = offsets[n];
+
+        // Check the nth `RuleSet` lib version.
+        assert_eq!(
+            data[rule_set_version_loc], RULE_SET_LIB_VERSION,
+            "The buffer doesn't match rule set {} lib version,",
+            n
+        );
+
+        // Serialize the nth `RuleSet` using RMP serde.
+        let mut serialized_rule_set = Vec::new();
+        rule_sets[n]
+            .serialize(&mut Serializer::new(&mut serialized_rule_set))
+            .unwrap();
+
+        // Check the first `RuleSet` serialized data.
+        let rule_set_start = rule_set_version_loc + 1;
+        let rule_set_end = rule_set_start + serialized_rule_set.len();
+        assert!(
+            cmp_slice(&data[rule_set_start..rule_set_end], &serialized_rule_set),
+            "The buffer doesn't match the serialized rule set {}.",
+            n,
+        );
+
+        // The end of `RuleSet` n is the offset for the next item.
+        offsets.push(rule_set_end)
+    }
+
+    // The final offset is the end of the last `RuleSet` and thus the start of the revision map.
+    let rev_map_version_loc = *offsets.last().unwrap();
+
+    // Check the revision map version.
+    assert_eq!(
+        data[rev_map_version_loc], RULE_SET_REV_MAP_VERSION,
+        "The buffer doesn't match the revision map version"
+    );
+
+    // Create revision map using the known locations of the two `RuleSet`s in this test.
+    let mut revision_map = RuleSetRevisionMapV1::default();
+
+    // Push the `RuleSet` locations.
+    for n in 0..rule_sets.len() {
+        revision_map.rule_set_revisions.push(offsets[n]);
+    }
+
+    // Borsh serialize the revision map.
+    let mut serialized_rev_map = Vec::new();
+    revision_map.serialize(&mut serialized_rev_map).unwrap();
+
+    // Check the revision map.  This should go to the end of the data slice.
+    let rev_map_start = rev_map_version_loc + 1;
+    assert!(
+        cmp_slice(&data[rev_map_start..], &serialized_rev_map),
+        "The buffer doesn't match the serialized revision map.",
+    );
+
+    // Create header using the known location of the revision map version location.
+    let header = RuleSetHeader::new(rev_map_version_loc);
+
+    // Borsh serialize the header.
+    let mut serialized_header = Vec::new();
+    header.serialize(&mut serialized_header).unwrap();
+
+    // Check the header.
+    assert!(
+        cmp_slice(&data[..RULE_SET_SERIALIZED_HEADER_LEN], &serialized_header),
+        "The buffer doesn't match the serialized header.",
+    );
+}
+
+#[tokio::test]
+async fn test_unknown_rule_set_revision_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSets
+    // --------------------------------
+    let additional_signer = Keypair::new();
+    let adtl_signer_rule = Rule::AdditionalSigner {
+        account: additional_signer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    first_rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer_rule)
+        .unwrap();
+
+    // Put the RuleSet on chain.
+    let _rule_set_addr = create_rule_set_on_chain!(
+        &mut context,
+        first_rule_set.clone(),
+        "test rule_set".to_string()
+    )
+    .await;
+
+    let amount_check = Rule::Amount {
+        amount: 10,
+        operator: CompareOp::Lt,
+        field: PayloadKey::Amount.to_string(),
+    };
+
+    // Create a new RuleSet.
+    let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    second_rule_set
+        .add(Operation::OwnerTransfer.to_string(), amount_check)
+        .unwrap();
+
+    // Put the updated RuleSet on chain.
+    let rule_set_addr = create_rule_set_on_chain!(
+        &mut context,
+        second_rule_set.clone(),
+        "test rule_set".to_string()
+    )
+    .await;
+
+    // --------------------------------
+    // Validate fail when trying to index a RuleSet revision that does not exist.
+    // --------------------------------
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Store a payload of data with an amount allowed by the the second revision `RuleSet`.
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(2))]);
+
+    // Create a `validate` instruction with the additional signer pubkey added as a signer, but with
+    // an unknown RuleSet revision.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            additional_signer.pubkey(),
+            true,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+            rule_set_revision: Some(3),
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![&additional_signer], None)
+            .await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::RuleSetRevisionNotAvailable);
+}
+
+#[tokio::test]
+async fn test_correct_rule_set_is_used_after_update() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSets
+    // --------------------------------
+    let additional_signer = Keypair::new();
+    let adtl_signer_rule = Rule::AdditionalSigner {
+        account: additional_signer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    first_rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer_rule)
+        .unwrap();
+
+    // Put the RuleSet on chain.
+    let _rule_set_addr = create_rule_set_on_chain!(
+        &mut context,
+        first_rule_set.clone(),
+        "test rule_set".to_string()
+    )
+    .await;
+
+    let amount_check = Rule::Amount {
+        amount: 10,
+        operator: CompareOp::Lt,
+        field: PayloadKey::Amount.to_string(),
+    };
+
+    // Create a new RuleSet.
+    let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    second_rule_set
+        .add(Operation::OwnerTransfer.to_string(), amount_check)
+        .unwrap();
+
+    // Put the updated RuleSet on chain.
+    let rule_set_addr = create_rule_set_on_chain!(
+        &mut context,
+        second_rule_set.clone(),
+        "test rule_set".to_string()
+    )
+    .await;
+
+    // --------------------------------
+    // Validate that when using first RuleSet, we fail based on inputs that would pass second RuleSet.
+    // --------------------------------
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Store a payload of data with an amount allowed by the the second revision `RuleSet` but ignored
+    // by the first `RuleSet`.
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(2))]);
+
+    // Create a `validate` instruction with the additional signer pubkey added but not sent as a signer.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            additional_signer.pubkey(),
+            false,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+            rule_set_revision: Some(0),
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::AdditionalSignerCheckFailed);
+
+    // --------------------------------
+    // Validate that when using first RuleSet, we pass based on inputs that would fail second RuleSet.
+    // --------------------------------
+    // Store a payload of data with an amount not allowed by the the second revision `RuleSet` but ignored
+    // by the first `RuleSet`.
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(200))]);
+
+    // Create a `validate` instruction with the additional signer pubkey added as a signer.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            additional_signer.pubkey(),
+            true,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+            rule_set_revision: Some(0),
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate Transfer operation.
+    process_passing_validate_ix!(&mut context, validate_ix, vec![&additional_signer], None).await;
+
+    // --------------------------------
+    // Validate that when using second RuleSet, we fail based on inputs that would pass first RuleSet.
+    // --------------------------------
+    // Store a payload of data with an amount not allowed by the the second revision `RuleSet` but ignored
+    // by the first `RuleSet`.
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(200))]);
+
+    // Create a `validate` instruction with the additional signer pubkey added as a signer.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            additional_signer.pubkey(),
+            true,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+            rule_set_revision: Some(1),
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![&additional_signer], None)
+            .await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
+
+    // --------------------------------
+    // Validate that when using second RuleSet, we pass based on inputs that would fail first RuleSet.
+    // --------------------------------
+    // Store a payload of data with an amount allowed by the the second revision `RuleSet` but ignored
+    // by the first `RuleSet`.
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(2))]);
+
+    // Create a `validate` instruction with the additional signer pubkey added but not sent as a signer.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            additional_signer.pubkey(),
+            false,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+            rule_set_revision: Some(1),
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate Transfer operation.
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+}


### PR DESCRIPTION
### Notes
* RuleSet update test now will validate 5 RuleSet revisions.
* Moving tests having to do with updated RuleSets to their
own file
* Adding test that creates two RuleSets and proves that the
correct RuleSet is being used.  It does this by sending inputs
that would pass for one and fail for the other and covers the
four combinations using two RuleSet revisions.
* Add test for unknown RuleSet revision.
* Also improve one error code name and regenerate IDL/SDK.

### Updated/new tests
```
running 3 tests
test test_unknown_rule_set_revision_fails ... ok
test test_correct_rule_set_is_used_after_update ... ok
test test_update_ruleset_data_integrity ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s
```