### PR TITLE
Removing `latest_revision` index in `RuleSet` rev map

### DIFF
--- a/packages/sdk/idl/mpl_token_auth_rules.json
+++ b/packages/sdk/idl/mpl_token_auth_rules.json
@@ -237,10 +237,6 @@
             "type": {
               "vec": "u64"
             }
-          },
-          {
-            "name": "latestRevision",
-            "type": "u64"
           }
         ]
       }

--- a/packages/sdk/src/generated/types/RuleSetRevisionMapV1.ts
+++ b/packages/sdk/src/generated/types/RuleSetRevisionMapV1.ts
@@ -8,7 +8,6 @@
 import * as beet from '@metaplex-foundation/beet';
 export type RuleSetRevisionMapV1 = {
   ruleSetRevisions: beet.bignum[];
-  latestRevision: beet.bignum;
 };
 
 /**
@@ -16,9 +15,6 @@ export type RuleSetRevisionMapV1 = {
  * @category generated
  */
 export const ruleSetRevisionMapV1Beet = new beet.FixableBeetArgsStruct<RuleSetRevisionMapV1>(
-  [
-    ['ruleSetRevisions', beet.array(beet.u64)],
-    ['latestRevision', beet.u64],
-  ],
+  [['ruleSetRevisions', beet.array(beet.u64)]],
   'RuleSetRevisionMapV1',
 );

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -128,19 +128,11 @@ fn create_or_update_v1(
         revision_map
             .rule_set_revisions
             .push(RULE_SET_SERIALIZED_HEADER_LEN);
-        revision_map.latest_revision = 0;
         revision_map
     } else {
         // Get existing revision map and its serialized length.
         let (mut revision_map, existing_rev_map_loc) =
             get_existing_revision_map(ctx.accounts.rule_set_pda_info)?;
-
-        // Update the revision map: Increment latest revision and save the new `RuleSet` revision's
-        // location.
-        revision_map.latest_revision = revision_map
-            .latest_revision
-            .checked_add(1)
-            .ok_or(RuleSetError::NumericalOverflow)?;
 
         // The next `RuleSet` revision will start where the existing revision map was.
         revision_map.rule_set_revisions.push(existing_rev_map_loc);
@@ -164,7 +156,10 @@ fn create_or_update_v1(
     // (RULE_SET_SERIALIZED_HEADER_LEN || existing latest revision map location)) +
     // 2 bytes for version numbers + length of the serialized revision map +
     // length of user-pre-serialized `RuleSet`.
-    let new_pda_data_len = revision_map.rule_set_revisions[revision_map.latest_revision]
+    let new_pda_data_len = revision_map
+        .rule_set_revisions
+        .last()
+        .ok_or(RuleSetError::RuleSetRevNotAvailable)?
         .checked_add(2)
         .and_then(|len| len.checked_add(serialized_rev_map.len()))
         .and_then(|len| len.checked_add(new_rule_set_data_len))
@@ -195,7 +190,10 @@ fn create_or_update_v1(
         Some(account_info) => {
             write_data_to_pda(
                 ctx.accounts.rule_set_pda_info,
-                revision_map.rule_set_revisions[revision_map.latest_revision],
+                *revision_map
+                    .rule_set_revisions
+                    .last()
+                    .ok_or(RuleSetError::RuleSetRevNotAvailable)?,
                 &serialized_rev_map,
                 &account_info.data.borrow(),
             )?;
@@ -203,7 +201,10 @@ fn create_or_update_v1(
         None => {
             write_data_to_pda(
                 ctx.accounts.rule_set_pda_info,
-                revision_map.rule_set_revisions[revision_map.latest_revision],
+                *revision_map
+                    .rule_set_revisions
+                    .last()
+                    .ok_or(RuleSetError::RuleSetRevNotAvailable)?,
                 &serialized_rev_map,
                 &serialized_rule_set,
             )?;

--- a/program/src/state/rule_set.rs
+++ b/program/src/state/rule_set.rs
@@ -39,9 +39,6 @@ pub const RULE_SET_SERIALIZED_HEADER_LEN: usize = 8;
 pub struct RuleSetRevisionMapV1 {
     /// `Vec` used to map a `RuleSet` revision number to its location in the PDA.
     pub rule_set_revisions: Vec<usize>,
-    /// The current latest revision stored in the PDA (essentially the greatest element of
-    /// `rule_set_revisions`).
-    pub latest_revision: usize,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -338,7 +338,6 @@ async fn test_update_ruleset() {
     revision_map
         .rule_set_revisions
         .push(second_rule_set_version_loc);
-    revision_map.latest_revision = 1;
 
     // Borsh serialize the revision map.
     let mut serialized_rev_map = Vec::new();


### PR DESCRIPTION
* This was originally needed for my earlier version that was array-based.
* The final design ended up using a Vec so we know the location inherently.