### PR TITLE
Return revision index

### DIFF
--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -181,5 +181,11 @@ pub fn get_existing_revision_map(
 /// revision map.
 pub fn get_latest_revision(rule_set_pda_info: &AccountInfo) -> Result<Option<usize>, ProgramError> {
     let (revision_map, _) = get_existing_revision_map(rule_set_pda_info)?;
-    Ok(revision_map.rule_set_revisions.last().copied())
+
+    match revision_map.rule_set_revisions.len() {
+        // we should always have at least one revision
+        0 => Err(RuleSetError::RuleSetRevNotAvailable.into()),
+        // determine the index of the last revision
+        length => Ok(Some(length - 1)),
+    }
 }

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -184,7 +184,7 @@ pub fn get_latest_revision(rule_set_pda_info: &AccountInfo) -> Result<Option<usi
 
     match revision_map.rule_set_revisions.len() {
         // we should always have at least one revision
-        0 => Err(RuleSetError::RuleSetRevNotAvailable.into()),
+        0 => Err(RuleSetError::RuleSetRevisionNotAvailable.into()),
         // determine the index of the last revision
         length => Ok(Some(length - 1)),
     }


### PR DESCRIPTION
This PR changes (fixes) the return of the `get_latest_revision` to be the index on the revision `Vec` instead of the value (byte offset) of the latest revision.