### PR TITLE
Update basic royalty enforcement BPF test

### DIFF
--- a/program/tests/additional_signer.rs
+++ b/program/tests/additional_signer.rs
@@ -29,7 +29,7 @@ async fn test_additional_signer() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -50,7 +50,7 @@ async fn test_additional_signer() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -73,7 +73,7 @@ async fn test_additional_signer() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(adtl_signer.pubkey(), false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -96,7 +96,7 @@ async fn test_additional_signer() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(adtl_signer.pubkey(), true)])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/all.rs
+++ b/program/tests/all.rs
@@ -39,7 +39,7 @@ async fn test_all() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), overall_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -66,7 +66,7 @@ async fn test_all() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -96,7 +96,7 @@ async fn test_all() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/amount.rs
+++ b/program/tests/amount.rs
@@ -62,7 +62,10 @@ async fn parametric_amount_check(
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), less_than_amount_check)
+        .add(
+            Operation::SimpleOwnerTransfer.to_string(),
+            less_than_amount_check,
+        )
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -89,7 +92,7 @@ async fn parametric_amount_check(
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -118,7 +121,7 @@ async fn parametric_amount_check(
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/any.rs
+++ b/program/tests/any.rs
@@ -37,7 +37,7 @@ async fn test_any() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), overall_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -61,7 +61,7 @@ async fn test_any() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -87,7 +87,7 @@ async fn test_any() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -162,11 +162,8 @@ async fn create_royalty_rule_set(context: &mut ProgramTestContext) -> Pubkey {
     println!("{:#?}", royalty_rule_set);
 
     // Put the `RuleSet` on chain.
-
-    let rule_set_addr =
-        create_big_rule_set_on_chain!(context, royalty_rule_set.clone(), RULE_SET_NAME.to_string())
-            .await;
-    rule_set_addr
+    create_big_rule_set_on_chain!(context, royalty_rule_set.clone(), RULE_SET_NAME.to_string())
+        .await
 }
 
 #[tokio::test]

--- a/program/tests/buffered_rule_set.rs
+++ b/program/tests/buffered_rule_set.rs
@@ -33,7 +33,7 @@ async fn buffered_rule_set() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
     let test_rule_set = rule_set.clone();
 
@@ -82,7 +82,7 @@ async fn buffered_rule_set() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -114,7 +114,7 @@ async fn buffered_rule_set() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/composed_rule.rs
+++ b/program/tests/composed_rule.rs
@@ -52,7 +52,7 @@ async fn composed_rule() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), overall_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), overall_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -79,7 +79,7 @@ async fn composed_rule() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -105,7 +105,7 @@ async fn composed_rule() {
             AccountMeta::new_readonly(second_signer.pubkey(), true),
         ])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -131,7 +131,7 @@ async fn composed_rule() {
             AccountMeta::new_readonly(second_signer.pubkey(), true),
         ])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/create_account_and_data_checks.rs
+++ b/program/tests/create_account_and_data_checks.rs
@@ -31,7 +31,7 @@ async fn create_payer_not_signer_panics() {
     let other_payer = Keypair::new();
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), other_payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), pass_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), pass_rule)
         .unwrap();
 
     // Find RuleSet PDA.
@@ -83,7 +83,7 @@ async fn create_rule_set_empty_buffer_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -153,7 +153,7 @@ async fn create_rule_set_partial_buffer_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -298,7 +298,7 @@ async fn create_rule_set_name_too_long_fails() {
     );
 
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -361,7 +361,7 @@ async fn create_rule_set_wrong_owner_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), Keypair::new().pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -423,7 +423,7 @@ async fn create_rule_set_buffer_with_different_name_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -524,7 +524,7 @@ async fn create_rule_set_to_wallet_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -580,7 +580,7 @@ async fn create_rule_set_to_wrong_pda_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.

--- a/program/tests/frequency.rs
+++ b/program/tests/frequency.rs
@@ -31,7 +31,7 @@ async fn test_frequency() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -52,7 +52,7 @@ async fn test_frequency() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -91,7 +91,7 @@ async fn test_frequency() {
         .rule_set_state_pda(rule_set_state_addr)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -118,7 +118,7 @@ async fn test_frequency() {
         .rule_set_state_pda(rule_set_state_addr)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,

--- a/program/tests/is_wallet.rs
+++ b/program/tests/is_wallet.rs
@@ -27,7 +27,7 @@ async fn is_wallet() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -55,7 +55,7 @@ async fn is_wallet() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(wallet.pubkey(), false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/not.rs
+++ b/program/tests/not.rs
@@ -32,7 +32,7 @@ async fn test_not() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), not_amount_check)
+        .add(Operation::SimpleOwnerTransfer.to_string(), not_amount_check)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -56,7 +56,7 @@ async fn test_not() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -82,7 +82,7 @@ async fn test_not() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/pass.rs
+++ b/program/tests/pass.rs
@@ -24,7 +24,7 @@ async fn test_pass() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), pass_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), pass_rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -45,7 +45,7 @@ async fn test_pass() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -30,7 +30,7 @@ async fn test_pda_match_assumed_owner() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -73,7 +73,7 @@ async fn test_pda_match_assumed_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(invalid_pda, false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -108,7 +108,7 @@ async fn test_pda_match_assumed_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![AccountMeta::new_readonly(rule_set_addr, false)])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -137,7 +137,7 @@ async fn test_pda_match_specified_owner() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -173,7 +173,7 @@ async fn test_pda_match_specified_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -212,7 +212,7 @@ async fn test_pda_match_specified_owner() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -31,7 +31,7 @@ async fn program_owned() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -65,7 +65,7 @@ async fn program_owned() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -115,7 +115,7 @@ async fn program_owned() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/program_owned_tree_match.rs
+++ b/program/tests/program_owned_tree_match.rs
@@ -40,7 +40,7 @@ async fn program_owned_tree_match() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -96,7 +96,7 @@ async fn program_owned_tree_match() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -179,7 +179,7 @@ async fn program_owned_tree_match() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -217,7 +217,7 @@ async fn program_owned_tree_match() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/pubkey_list_match.rs
+++ b/program/tests/pubkey_list_match.rs
@@ -32,7 +32,7 @@ async fn test_pubkey_list_match() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -59,7 +59,7 @@ async fn test_pubkey_list_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -91,7 +91,7 @@ async fn test_pubkey_list_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/pubkey_match.rs
+++ b/program/tests/pubkey_match.rs
@@ -30,7 +30,7 @@ async fn test_pubkey_match() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -57,7 +57,7 @@ async fn test_pubkey_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -86,7 +86,7 @@ async fn test_pubkey_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/pubkey_tree_match.rs
+++ b/program/tests/pubkey_tree_match.rs
@@ -37,7 +37,7 @@ async fn pubkey_tree_match() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     println!("{:#?}", rule_set);
@@ -94,7 +94,7 @@ async fn pubkey_tree_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,
@@ -144,7 +144,7 @@ async fn pubkey_tree_match() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload,
             update_rule_state: false,
             rule_set_revision: None,

--- a/program/tests/updated_rule_set.rs
+++ b/program/tests/updated_rule_set.rs
@@ -35,7 +35,7 @@ async fn test_update_ruleset_data_integrity() {
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
-            Operation::OwnerTransfer.to_string(),
+            Operation::SimpleOwnerTransfer.to_string(),
             first_overall_rule.clone(),
         )
         .unwrap();
@@ -73,12 +73,15 @@ async fn test_update_ruleset_data_integrity() {
     // Create a new RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::Delegate.to_string(), second_overall_rule.clone())
+        .add(
+            Operation::SimpleDelegate.to_string(),
+            second_overall_rule.clone(),
+        )
         .unwrap();
 
     rule_set
         .add(
-            Operation::SaleTransfer.to_string(),
+            Operation::SimpleSaleTransfer.to_string(),
             second_overall_rule.clone(),
         )
         .unwrap();
@@ -119,7 +122,7 @@ async fn test_update_ruleset_data_integrity() {
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
-            Operation::OwnerTransfer.to_string(),
+            Operation::SimpleOwnerTransfer.to_string(),
             third_overall_rule.clone(),
         )
         .unwrap();
@@ -141,13 +144,22 @@ async fn test_update_ruleset_data_integrity() {
     // Create a new RuleSet reusing some previous rules.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), first_overall_rule)
+        .add(
+            Operation::SimpleOwnerTransfer.to_string(),
+            first_overall_rule,
+        )
         .unwrap();
     rule_set
-        .add(Operation::Delegate.to_string(), second_overall_rule.clone())
+        .add(
+            Operation::SimpleDelegate.to_string(),
+            second_overall_rule.clone(),
+        )
         .unwrap();
     rule_set
-        .add(Operation::SaleTransfer.to_string(), second_overall_rule)
+        .add(
+            Operation::SimpleSaleTransfer.to_string(),
+            second_overall_rule,
+        )
         .unwrap();
 
     // Save RuleSet for validation later.
@@ -167,7 +179,10 @@ async fn test_update_ruleset_data_integrity() {
     // Create a new RuleSet reusing some previous rules.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), third_overall_rule)
+        .add(
+            Operation::SimpleOwnerTransfer.to_string(),
+            third_overall_rule,
+        )
         .unwrap();
 
     // Save RuleSet for validation later.
@@ -281,7 +296,7 @@ async fn test_unknown_rule_set_revision_fails() {
     // Create a RuleSet.
     let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     first_rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer_rule)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -301,7 +316,7 @@ async fn test_unknown_rule_set_revision_fails() {
     // Create a new RuleSet.
     let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     second_rule_set
-        .add(Operation::OwnerTransfer.to_string(), amount_check)
+        .add(Operation::SimpleOwnerTransfer.to_string(), amount_check)
         .unwrap();
 
     // Put the updated RuleSet on chain.
@@ -331,7 +346,7 @@ async fn test_unknown_rule_set_revision_fails() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: Some(3),
@@ -363,7 +378,7 @@ async fn test_correct_rule_set_is_used_after_update() {
     // Create a RuleSet.
     let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     first_rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer_rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer_rule)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -383,7 +398,7 @@ async fn test_correct_rule_set_is_used_after_update() {
     // Create a new RuleSet.
     let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     second_rule_set
-        .add(Operation::OwnerTransfer.to_string(), amount_check)
+        .add(Operation::SimpleOwnerTransfer.to_string(), amount_check)
         .unwrap();
 
     // Put the updated RuleSet on chain.
@@ -413,7 +428,7 @@ async fn test_correct_rule_set_is_used_after_update() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: Some(0),
@@ -443,7 +458,7 @@ async fn test_correct_rule_set_is_used_after_update() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: Some(0),
@@ -470,7 +485,7 @@ async fn test_correct_rule_set_is_used_after_update() {
             true,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: Some(1),
@@ -502,7 +517,7 @@ async fn test_correct_rule_set_is_used_after_update() {
             false,
         )])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: payload.clone(),
             update_rule_state: false,
             rule_set_revision: Some(1),

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -14,21 +14,63 @@ use solana_sdk::{
     compute_budget::ComputeBudgetInstruction, program_pack::Pack, signature::Signer,
     signer::keypair::Keypair, system_instruction, transaction::Transaction,
 };
+use std::fmt::Display;
 
-#[repr(C)]
-#[derive(ToPrimitive)]
-pub enum Operation {
-    OwnerTransfer,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransferScenario {
+    Holder,
+    TransferDelegate,
+    SaleDelegate,
+    MigrationDelegate,
+    WalletToWallet,
+}
+
+impl Display for TransferScenario {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Holder => write!(f, "Owner"),
+            Self::TransferDelegate => write!(f, "TransferDelegate"),
+            Self::SaleDelegate => write!(f, "SaleDelegate"),
+            Self::MigrationDelegate => write!(f, "MigrationDelegate"),
+            Self::WalletToWallet => write!(f, "WalletToWallet"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpdateScenario {
+    MetadataAuth,
     Delegate,
-    SaleTransfer,
+    Proxy,
+}
+
+impl Display for UpdateScenario {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateScenario::MetadataAuth => write!(f, "MetadataAuth"),
+            UpdateScenario::Delegate => write!(f, "Delegate"),
+            UpdateScenario::Proxy => write!(f, "Proxy"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Operation {
+    SimpleOwnerTransfer,
+    SimpleDelegate,
+    SimpleSaleTransfer,
+    Transfer { scenario: TransferScenario },
+    Update { scenario: UpdateScenario },
 }
 
 impl ToString for Operation {
     fn to_string(&self) -> String {
         match self {
-            Operation::OwnerTransfer => "OwnerTransfer".to_string(),
-            Operation::Delegate => "Delegate".to_string(),
-            Operation::SaleTransfer => "SaleTransfer".to_string(),
+            Operation::SimpleOwnerTransfer => "SimpleOwnerTransfer".to_string(),
+            Operation::SimpleDelegate => "SimpleDelegate".to_string(),
+            Operation::SimpleSaleTransfer => "SimpleSaleTransfer".to_string(),
+            Self::Transfer { scenario } => format!("Transfer:{}", scenario),
+            Self::Update { scenario } => format!("Update:{}", scenario),
         }
     }
 }

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -27,7 +27,7 @@ async fn validate_update_rule_state_payer_not_signer_panics() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .add(Operation::SimpleOwnerTransfer.to_string(), Rule::Pass)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -56,7 +56,7 @@ async fn validate_update_rule_state_payer_not_signer_panics() {
         .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -83,7 +83,7 @@ async fn validate_update_rule_state_payer_not_provided_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .add(Operation::SimpleOwnerTransfer.to_string(), Rule::Pass)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -110,7 +110,7 @@ async fn validate_update_rule_state_payer_not_provided_fails() {
         .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -149,7 +149,7 @@ async fn validate_rule_set_with_wallet_fails() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -183,7 +183,7 @@ async fn validate_rule_set_with_uninitialized_pda_fails() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -230,7 +230,7 @@ async fn validate_rule_set_with_zero_data_fails() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -279,7 +279,7 @@ async fn validate_rule_set_with_incorrect_data_fails() {
         .mint(mint)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: false,
             rule_set_revision: None,
@@ -302,7 +302,7 @@ async fn validate_update_rule_state_wrong_state_pda_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .add(Operation::SimpleOwnerTransfer.to_string(), Rule::Pass)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -331,7 +331,7 @@ async fn validate_update_rule_state_wrong_state_pda_fails() {
         .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -354,7 +354,7 @@ async fn validate_update_rule_state_state_pda_not_provided_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .add(Operation::SimpleOwnerTransfer.to_string(), Rule::Pass)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -374,7 +374,7 @@ async fn validate_update_rule_state_state_pda_not_provided_fails() {
         .rule_authority(rule_authority.pubkey())
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -413,7 +413,7 @@ async fn validate_update_rule_state_incorrect_auth() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -439,7 +439,7 @@ async fn validate_update_rule_state_incorrect_auth() {
         .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,
@@ -467,7 +467,7 @@ async fn validate_update_rule_state_missing_auth() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), rule)
+        .add(Operation::SimpleOwnerTransfer.to_string(), rule)
         .unwrap();
 
     // Put the RuleSet on chain.
@@ -492,7 +492,7 @@ async fn validate_update_rule_state_missing_auth() {
         .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
+            operation: Operation::SimpleOwnerTransfer.to_string(),
             payload: Payload::default(),
             update_rule_state: true,
             rule_set_revision: None,

--- a/program/tests/write_to_buffer_account_and_data_checks.rs
+++ b/program/tests/write_to_buffer_account_and_data_checks.rs
@@ -29,7 +29,7 @@ async fn write_to_buffer_payer_not_signer_panics() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.
@@ -86,7 +86,7 @@ async fn write_to_buffer_wrong_pda_fails() {
     // Create a RuleSet.
     let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
-        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .add(Operation::SimpleOwnerTransfer.to_string(), adtl_signer)
         .unwrap();
 
     // Serialize the RuleSet using RMP serde.


### PR DESCRIPTION
### Notes
* Use new dev version of Royalty `RuleSet` which includes current token-metadata operations/scenarios.
* Also separating basic royalty enforcement tests into separate cases.

### NOTE THIS PR IS BUILT UPON https://github.com/metaplex-foundation/mpl-token-auth-rules/pull/95