### PR TITLE
Add more BPF tests

### DIFF
--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -490,6 +490,8 @@ impl Rule {
                 msg!("Validating Frequency");
 
                 if let Some(rule_authority) = rule_authority {
+                    // TODO: If it's the wrong account (first condition) the `IsNotASigner`
+                    // is misleading.  Should be improved, perhaps with a `Mismatch` error.
                     if authority != rule_authority.key || !rule_authority.is_signer {
                         return (false, RuleSetError::RuleAuthorityIsNotSigner.into());
                     }

--- a/program/tests/composed_rule.rs
+++ b/program/tests/composed_rule.rs
@@ -1,0 +1,148 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod utils;
+
+use mpl_token_auth_rules::{
+    error::RuleSetError,
+    instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
+    payload::{Payload, PayloadType},
+    state::{CompareOp, Rule, RuleSetV1},
+};
+
+use solana_program::instruction::AccountMeta;
+use solana_program_test::tokio;
+use solana_sdk::{signature::Signer, signer::keypair::Keypair};
+use utils::{program_test, Operation, PayloadKey};
+
+#[tokio::test]
+async fn composed_rule() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Second signer.
+    let second_signer = Keypair::new();
+
+    let adtl_signer2 = Rule::AdditionalSigner {
+        account: second_signer.pubkey(),
+    };
+    let amount_check = Rule::Amount {
+        amount: 1,
+        operator: CompareOp::Eq,
+        field: PayloadKey::Amount.to_string(),
+    };
+    let not_amount_check = Rule::Not {
+        rule: Box::new(amount_check),
+    };
+
+    let first_rule = Rule::All {
+        rules: vec![adtl_signer, adtl_signer2],
+    };
+
+    let overall_rule = Rule::All {
+        rules: vec![first_rule, not_amount_check],
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), overall_rule)
+        .unwrap();
+
+    println!("{:#?}", rule_set);
+
+    // Put the RuleSet on chain.
+    let rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // --------------------------------
+    // Validate fail missing account
+    // --------------------------------
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Store a payload of data with an amount not allowed by the Amount Rule (Amount Rule NOT'd).
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(2))]);
+
+    // Create a `validate` instruction WITHOUT the second signer.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![AccountMeta::new_readonly(
+            context.payer.pubkey(),
+            true,
+        )])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: payload.clone(),
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::MissingAccount);
+
+    // --------------------------------
+    // Validate pass
+    // --------------------------------
+    // Create a `validate` instruction WITH the second signer.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+            AccountMeta::new_readonly(second_signer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate Transfer operation.
+    process_passing_validate_ix!(&mut context, validate_ix, vec![&second_signer], None).await;
+
+    // --------------------------------
+    // Validate fail wrong amount
+    // --------------------------------
+    // Store a payload of data with an amount allowed by the Amount Rule (Amount Rule NOT'd).
+    let payload = Payload::from([(PayloadKey::Amount.to_string(), PayloadType::Number(1))]);
+
+    // Create a `validate` instruction WITH the second signer.  Will fail as Amount Rule is NOT'd.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+            AccountMeta::new_readonly(second_signer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate Transfer operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![&second_signer], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::AmountCheckFailed);
+}

--- a/program/tests/create_account_and_data_checks.rs
+++ b/program/tests/create_account_and_data_checks.rs
@@ -169,7 +169,7 @@ async fn create_rule_set_partial_buffer_fails() {
         mpl_token_auth_rules::pda::find_buffer_address(context.payer.pubkey());
 
     // Create a `write_to_buffer` instruction.
-    let create_ix = WriteToBufferBuilder::new()
+    let write_to_buffer_ix = WriteToBufferBuilder::new()
         .payer(context.payer.pubkey())
         .buffer_pda(buffer_pda)
         .build(WriteToBufferArgs::V1 {
@@ -180,8 +180,8 @@ async fn create_rule_set_partial_buffer_fails() {
         .instruction();
 
     // Add it to a transaction.
-    let create_tx = Transaction::new_signed_with_payer(
-        &[create_ix],
+    let write_to_buffer_tx = Transaction::new_signed_with_payer(
+        &[write_to_buffer_ix],
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -190,7 +190,7 @@ async fn create_rule_set_partial_buffer_fails() {
     // Process the transaction.
     context
         .banks_client
-        .process_transaction(create_tx)
+        .process_transaction(write_to_buffer_tx)
         .await
         .unwrap();
 

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -415,6 +415,73 @@ async fn test_rule_set_creation_empty_rule_set_fails() {
 }
 
 #[tokio::test]
+async fn test_rule_set_name_too_long_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new(
+        "test rule_set that has too long of a name".to_string(),
+        context.payer.pubkey(),
+    );
+
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // --------------------------------
+    // Fail on-chain creation
+    // --------------------------------
+    // Find RuleSet PDA.  This isn't the correct PDA but we expect to fail because the name in the
+    // serialized `RuleSet` is too long.
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    // Create a `create` instruction.
+    let create_ix = CreateOrUpdateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .build(CreateOrUpdateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    let err = context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .expect_err("Creation should fail");
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::NameTooLong);
+}
+
+#[tokio::test]
 async fn test_rule_set_creation_to_wallet_fails() {
     let mut context = program_test().start_with_context().await;
 

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -204,7 +204,7 @@ async fn test_composed_rule() {
 }
 
 #[tokio::test]
-async fn test_rule_set_creation_wallet_fails() {
+async fn test_rule_set_creation_to_wallet_fails() {
     let mut context = program_test().start_with_context().await;
 
     // --------------------------------
@@ -260,7 +260,7 @@ async fn test_rule_set_creation_wallet_fails() {
 }
 
 #[tokio::test]
-async fn test_rule_set_creation_wrong_pda_fails() {
+async fn test_rule_set_creation_to_wrong_pda_fails() {
     let mut context = program_test().start_with_context().await;
 
     // --------------------------------
@@ -322,7 +322,7 @@ async fn test_rule_set_creation_wrong_pda_fails() {
 }
 
 #[tokio::test]
-async fn test_rule_set_validate_wallet_fails() {
+async fn test_rule_set_validate_with_wallet_fails() {
     let mut context = program_test().start_with_context().await;
 
     // --------------------------------
@@ -356,7 +356,7 @@ async fn test_rule_set_validate_wallet_fails() {
 }
 
 #[tokio::test]
-async fn test_rule_set_validate_uninitialized_pda_fails() {
+async fn test_rule_set_validate_with_uninitialized_pda_fails() {
     let mut context = program_test().start_with_context().await;
 
     // Find RuleSet PDA.

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -202,3 +202,62 @@ async fn test_composed_rule() {
     // Check that error is what we expect.
     assert_custom_error!(err, RuleSetError::AmountCheckFailed);
 }
+
+#[tokio::test]
+async fn test_rule_set_creation_wrong_pda_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .unwrap();
+
+    // Find RuleSet PDA using WRONG name for seed.
+    let (wrong_rule_set_pda, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "WRONG NAME".to_string(),
+    );
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // Create a `create` instruction.
+    let create_ix = CreateOrUpdateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(wrong_rule_set_pda)
+        .build(CreateOrUpdateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    let err = context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .expect_err("Creation should fail");
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::DerivedKeyInvalid);
+}

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -5,8 +5,8 @@ pub mod utils;
 use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{
-        builders::{CreateOrUpdateBuilder, ValidateBuilder},
-        CreateOrUpdateArgs, InstructionBuilder, ValidateArgs,
+        builders::{CreateOrUpdateBuilder, ValidateBuilder, WriteToBufferBuilder},
+        CreateOrUpdateArgs, InstructionBuilder, ValidateArgs, WriteToBufferArgs,
     },
     payload::{Payload, PayloadType},
     state::{CompareOp, Rule, RuleSetV1},
@@ -201,6 +201,175 @@ async fn test_payer_not_signer_panics() {
 
     // Process the transaction.  It will panic because of not enough signers.
     let _result = context.banks_client.process_transaction(create_tx).await;
+}
+
+#[tokio::test]
+async fn test_rule_set_creation_empty_buffer_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // --------------------------------
+    // Fail on-chain creation
+    // --------------------------------
+    // Find RuleSet PDA.
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    let (buffer_pda, _buffer_bump) =
+        mpl_token_auth_rules::pda::find_buffer_address(context.payer.pubkey());
+
+    // Create a `create` instruction.  We are adding an uninitialized buffer as an extra account,
+    // which will be used instead of the `serialized_rule_set` arg that is passed in.  Normally
+    // when passing in a buffer account, the `serialized_rule_set` would just be an empty Vec, but
+    // for this test we are trying to prove that we fail due to the empty buffer, so we pass in a
+    // `serialized_rule_set` that would otherwise pass.
+    let create_ix = CreateOrUpdateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .buffer_pda(buffer_pda)
+        .build(CreateOrUpdateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    let err = context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .expect_err("Creation should fail");
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::MessagePackDeserializationError);
+}
+
+#[tokio::test]
+async fn test_rule_set_creation_partial_buffer_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // Get one partial chunk of the serialized `RuleSet`.
+    let serialized_rule_set_chunk = serialized_rule_set.chunks(100).next().unwrap();
+
+    let (buffer_pda, _buffer_bump) =
+        mpl_token_auth_rules::pda::find_buffer_address(context.payer.pubkey());
+
+    // Create a `write_to_buffer` instruction.
+    let create_ix = WriteToBufferBuilder::new()
+        .payer(context.payer.pubkey())
+        .buffer_pda(buffer_pda)
+        .build(WriteToBufferArgs::V1 {
+            serialized_rule_set: serialized_rule_set_chunk.to_vec(),
+            overwrite: true,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .unwrap();
+
+    // --------------------------------
+    // Fail on-chain creation
+    // --------------------------------
+    // Find RuleSet PDA.
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    // Create a `create` instruction.  We are adding an partially written buffer as an extra account,
+    // which will be used instead of the `serialized_rule_set` arg that is passed in.  Normally
+    // when passing in a buffer account, the `serialized_rule_set` would just be an empty Vec, but
+    // for this test we are trying to prove that we fail due to the partial buffer, so we pass in a
+    // `serialized_rule_set` that would otherwise pass.
+    let create_ix = CreateOrUpdateBuilder::new()
+        .payer(context.payer.pubkey())
+        .rule_set_pda(rule_set_addr)
+        .buffer_pda(buffer_pda)
+        .build(CreateOrUpdateArgs::V1 {
+            serialized_rule_set,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    let err = context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .expect_err("Creation should fail");
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::MessagePackDeserializationError);
 }
 
 #[tokio::test]

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -114,7 +114,7 @@ pub async fn create_rule_set_on_chain_with_loc(
         .serialize(&mut Serializer::new(&mut serialized_rule_set))
         .unwrap();
 
-    // Create a `create` instruction.
+    // Create a `create_or_update` instruction.
     let create_ix = CreateOrUpdateBuilder::new()
         .payer(context.payer.pubkey())
         .rule_set_pda(rule_set_addr)
@@ -189,7 +189,7 @@ pub async fn create_big_rule_set_on_chain_with_loc(
 
     let mut overwrite = true;
     for serialized_rule_set_chunk in serialized_rule_set.chunks(1000) {
-        // Create a `create` instruction.
+        // Create a `write_to_buffer` instruction.
         let create_ix = WriteToBufferBuilder::new()
             .payer(context.payer.pubkey())
             .buffer_pda(buffer_pda)

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -190,7 +190,7 @@ pub async fn create_big_rule_set_on_chain_with_loc(
     let mut overwrite = true;
     for serialized_rule_set_chunk in serialized_rule_set.chunks(1000) {
         // Create a `write_to_buffer` instruction.
-        let create_ix = WriteToBufferBuilder::new()
+        let write_to_buffer_ix = WriteToBufferBuilder::new()
             .payer(context.payer.pubkey())
             .buffer_pda(buffer_pda)
             .build(WriteToBufferArgs::V1 {
@@ -201,23 +201,26 @@ pub async fn create_big_rule_set_on_chain_with_loc(
             .instruction();
 
         // Add it to a transaction.
-        let create_tx = Transaction::new_signed_with_payer(
-            &[create_ix],
+        let write_to_buffer_tx = Transaction::new_signed_with_payer(
+            &[write_to_buffer_ix],
             Some(&context.payer.pubkey()),
             &[&context.payer],
             context.last_blockhash,
         );
 
-        println!("TX Length: {:?}", create_tx.message.serialize().len());
+        println!(
+            "TX Length: {:?}",
+            write_to_buffer_tx.message.serialize().len()
+        );
         assert!(
-            create_tx.message.serialize().len() <= 1232,
+            write_to_buffer_tx.message.serialize().len() <= 1232,
             "Transaction exceeds packet limit of 1232"
         );
 
         // Process the transaction.
         context
             .banks_client
-            .process_transaction(create_tx)
+            .process_transaction(write_to_buffer_tx)
             .await
             .unwrap_or_else(|err| {
                 panic!(

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -13,14 +13,19 @@ use mpl_token_auth_rules::{
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
-use solana_program::instruction::AccountMeta;
-use solana_program_test::tokio;
-use solana_sdk::{signature::Signer, signer::keypair::Keypair, transaction::Transaction};
+use solana_program::program_error::ProgramError;
+use solana_program::{instruction::AccountMeta, system_instruction};
+use solana_program_test::{tokio, BanksClientError};
+use solana_sdk::{
+    signature::Signer,
+    signer::keypair::Keypair,
+    transaction::{Transaction, TransactionError},
+};
 use utils::{program_test, Operation};
 
 #[tokio::test]
 #[should_panic]
-async fn validate_payer_not_signer_panics() {
+async fn validate_update_rule_state_payer_not_signer_panics() {
     let mut context = program_test().start_with_context().await;
 
     // Find RuleSet PDA.
@@ -61,12 +66,53 @@ async fn validate_payer_not_signer_panics() {
 }
 
 #[tokio::test]
+async fn validate_update_rule_state_payer_not_provided_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // Find RuleSet PDA.
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Create a `validate` instruction with `update_rule_state` set to true.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: true,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Deconstruct the error code and make sure it is what we expect.
+    match err {
+        BanksClientError::TransactionError(TransactionError::InstructionError(0, err)) => {
+            assert_eq!(
+                ProgramError::try_from(err).unwrap_or_else(|_| panic!(
+                    "Could not convert InstructionError to ProgramError",
+                )),
+                ProgramError::NotEnoughAccountKeys,
+            );
+        }
+        _ => panic!("Unexpected error: {}", err),
+    }
+}
+
+#[tokio::test]
 async fn validate_rule_set_with_wallet_fails() {
     let mut context = program_test().start_with_context().await;
 
-    // --------------------------------
-    // Validate fail incorrect owner
-    // --------------------------------
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
@@ -101,9 +147,6 @@ async fn validate_rule_set_with_uninitialized_pda_fails() {
         "test rule_set".to_string(),
     );
 
-    // --------------------------------
-    // Validate fail incorrect owner
-    // --------------------------------
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
@@ -126,4 +169,51 @@ async fn validate_rule_set_with_uninitialized_pda_fails() {
 
     // Check that error is what we expect.
     assert_custom_error!(err, RuleSetError::IncorrectOwner);
+}
+
+#[tokio::test]
+async fn validate_rule_set_with_zero_data_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // Create an account owned by mpl-token-auth-rules.  This isn't a PDA but we expect to fail
+    // before the derivation check because the data length is zero.
+    let program_owned_account = Keypair::new();
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[system_instruction::create_account(
+            &context.payer.pubkey(),
+            &program_owned_account.pubkey(),
+            rent.minimum_balance(0),
+            0,
+            &mpl_token_auth_rules::ID,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &program_owned_account],
+        context.last_blockhash,
+    );
+
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(program_owned_account.pubkey())
+        .mint(mint)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::DataIsEmpty);
 }

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -300,6 +300,58 @@ async fn validate_rule_set_with_incorrect_data_fails() {
 }
 
 #[tokio::test]
+async fn validate_update_rule_state_wrong_state_pda_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .unwrap();
+
+    // Put the RuleSet on chain.
+    let rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    let rule_authority = Keypair::new();
+
+    // Find RuleSet state PDA using WRONG NAME for seed.
+    let (rule_set_state_pda, _rule_set_state_pda_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "WRONG NAME".to_string(),
+            mint,
+        );
+
+    // Create a `validate` instruction with `update_rule_state` set to true.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(context.payer.pubkey())
+        .rule_authority(rule_authority.pubkey())
+        .rule_set_state_pda(rule_set_state_pda)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: true,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![&rule_authority], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::DerivedKeyInvalid);
+}
+
+#[tokio::test]
 async fn validate_update_rule_state_state_pda_not_provided_fails() {
     let mut context = program_test().start_with_context().await;
 
@@ -350,56 +402,4 @@ async fn validate_update_rule_state_state_pda_not_provided_fails() {
         }
         _ => panic!("Unexpected error: {}", err),
     }
-}
-
-#[tokio::test]
-async fn validate_update_rule_state_wrong_state_pda_fails() {
-    let mut context = program_test().start_with_context().await;
-
-    // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
-    rule_set
-        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
-        .unwrap();
-
-    // Put the RuleSet on chain.
-    let rule_set_addr =
-        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
-
-    // Create a Keypair to simulate a token mint address.
-    let mint = Keypair::new().pubkey();
-
-    let rule_authority = Keypair::new();
-
-    // Find RuleSet state PDA using WRONG NAME for seed.
-    let (rule_set_state_pda, _rule_set_state_pda_bump) =
-        mpl_token_auth_rules::pda::find_rule_set_state_address(
-            context.payer.pubkey(),
-            "WRONG NAME".to_string(),
-            mint,
-        );
-
-    // Create a `validate` instruction with `update_rule_state` set to true.
-    let validate_ix = ValidateBuilder::new()
-        .rule_set_pda(rule_set_addr)
-        .mint(mint)
-        .payer(context.payer.pubkey())
-        .rule_authority(rule_authority.pubkey())
-        .rule_set_state_pda(rule_set_state_pda)
-        .additional_rule_accounts(vec![])
-        .build(ValidateArgs::V1 {
-            operation: Operation::OwnerTransfer.to_string(),
-            payload: Payload::default(),
-            update_rule_state: true,
-            rule_set_revision: None,
-        })
-        .unwrap()
-        .instruction();
-
-    // Fail to validate operation.
-    let err =
-        process_failing_validate_ix!(&mut context, validate_ix, vec![&rule_authority], None).await;
-
-    // Check that error is what we expect.
-    assert_custom_error!(err, RuleSetError::DerivedKeyInvalid);
 }

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -4,17 +4,13 @@ pub mod utils;
 
 use mpl_token_auth_rules::{
     error::RuleSetError,
-    instruction::{
-        builders::{CreateOrUpdateBuilder, ValidateBuilder, WriteToBufferBuilder},
-        CreateOrUpdateArgs, InstructionBuilder, ValidateArgs, WriteToBufferArgs,
-    },
+    instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::Payload,
     state::{Rule, RuleSetV1},
 };
-use rmp_serde::Serializer;
-use serde::Serialize;
+
 use solana_program::program_error::ProgramError;
-use solana_program::{instruction::AccountMeta, system_instruction};
+use solana_program::system_instruction;
 use solana_program_test::{tokio, BanksClientError};
 use solana_sdk::{
     signature::Signer,

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -1,0 +1,129 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod utils;
+
+use mpl_token_auth_rules::{
+    error::RuleSetError,
+    instruction::{
+        builders::{CreateOrUpdateBuilder, ValidateBuilder, WriteToBufferBuilder},
+        CreateOrUpdateArgs, InstructionBuilder, ValidateArgs, WriteToBufferArgs,
+    },
+    payload::Payload,
+    state::{Rule, RuleSetV1},
+};
+use rmp_serde::Serializer;
+use serde::Serialize;
+use solana_program::instruction::AccountMeta;
+use solana_program_test::tokio;
+use solana_sdk::{signature::Signer, signer::keypair::Keypair, transaction::Transaction};
+use utils::{program_test, Operation};
+
+#[tokio::test]
+#[should_panic]
+async fn validate_payer_not_signer_panics() {
+    let mut context = program_test().start_with_context().await;
+
+    // Find RuleSet PDA.
+    let other_payer = Keypair::new();
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        other_payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Create a `validate` instruction with `update_rule_state` set to true.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(other_payer.pubkey())
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: true,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add ix to a transaction.
+    let validate_tx = Transaction::new_signed_with_payer(
+        &[validate_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.  It will panic because of not enough signers.
+    let _result = context.banks_client.process_transaction(validate_tx).await;
+}
+
+#[tokio::test]
+async fn validate_rule_set_with_wallet_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Validate fail incorrect owner
+    // --------------------------------
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(Keypair::new().pubkey())
+        .mint(mint)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::IncorrectOwner);
+}
+
+#[tokio::test]
+async fn validate_rule_set_with_uninitialized_pda_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // Find RuleSet PDA.
+    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
+        context.payer.pubkey(),
+        "test rule_set".to_string(),
+    );
+
+    // --------------------------------
+    // Validate fail incorrect owner
+    // --------------------------------
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::IncorrectOwner);
+}

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -28,21 +28,36 @@ use utils::{program_test, Operation};
 async fn validate_update_rule_state_payer_not_signer_panics() {
     let mut context = program_test().start_with_context().await;
 
-    // Find RuleSet PDA.
-    let other_payer = Keypair::new();
-    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
-        other_payer.pubkey(),
-        "test rule_set".to_string(),
-    );
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .unwrap();
+
+    // Put the RuleSet on chain.
+    let rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
 
+    let rule_authority = Keypair::new();
+
+    let (rule_set_state_pda, _rule_set_state_pda_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "test rule_set".to_string(),
+            mint,
+        );
+
     // Create a `validate` instruction with `update_rule_state` set to true.
+    let other_payer = Keypair::new();
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
         .payer(other_payer.pubkey())
+        .rule_authority(rule_authority.pubkey())
+        .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::OwnerTransfer.to_string(),
@@ -57,7 +72,7 @@ async fn validate_update_rule_state_payer_not_signer_panics() {
     let validate_tx = Transaction::new_signed_with_payer(
         &[validate_ix],
         Some(&context.payer.pubkey()),
-        &[&context.payer],
+        &[&context.payer, &rule_authority],
         context.last_blockhash,
     );
 
@@ -69,19 +84,34 @@ async fn validate_update_rule_state_payer_not_signer_panics() {
 async fn validate_update_rule_state_payer_not_provided_fails() {
     let mut context = program_test().start_with_context().await;
 
-    // Find RuleSet PDA.
-    let (rule_set_addr, _rule_set_bump) = mpl_token_auth_rules::pda::find_rule_set_address(
-        context.payer.pubkey(),
-        "test rule_set".to_string(),
-    );
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .unwrap();
+
+    // Put the RuleSet on chain.
+    let rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
 
     // Create a Keypair to simulate a token mint address.
     let mint = Keypair::new().pubkey();
+
+    let rule_authority = Keypair::new();
+
+    let (rule_set_state_pda, _rule_set_state_pda_bump) =
+        mpl_token_auth_rules::pda::find_rule_set_state_address(
+            context.payer.pubkey(),
+            "test rule_set".to_string(),
+            mint,
+        );
 
     // Create a `validate` instruction with `update_rule_state` set to true.
     let validate_ix = ValidateBuilder::new()
         .rule_set_pda(rule_set_addr)
         .mint(mint)
+        .rule_authority(rule_authority.pubkey())
+        .rule_set_state_pda(rule_set_state_pda)
         .additional_rule_accounts(vec![])
         .build(ValidateArgs::V1 {
             operation: Operation::OwnerTransfer.to_string(),
@@ -93,7 +123,8 @@ async fn validate_update_rule_state_payer_not_provided_fails() {
         .instruction();
 
     // Fail to validate operation.
-    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![&rule_authority], None).await;
 
     // Deconstruct the error code and make sure it is what we expect.
     match err {
@@ -216,4 +247,106 @@ async fn validate_rule_set_with_zero_data_fails() {
 
     // Check that error is what we expect.
     assert_custom_error!(err, RuleSetError::DataIsEmpty);
+}
+
+#[tokio::test]
+async fn validate_rule_set_with_incorrect_data_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // Create an account owned by mpl-token-auth-rules.  This isn't a PDA but we expect to fail
+    // before the derivation check because the data will not deserialize properly into a `RuleSet`.
+    // The deserialization is done in the processor before the derivation check because the
+    // derivation uses the `RuleSet` name and owner from the deserialized data as seeds.
+    let program_owned_account = Keypair::new();
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[system_instruction::create_account(
+            &context.payer.pubkey(),
+            &program_owned_account.pubkey(),
+            rent.minimum_balance(1000),
+            1000,
+            &mpl_token_auth_rules::ID,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &program_owned_account],
+        context.last_blockhash,
+    );
+
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(program_owned_account.pubkey())
+        .mint(mint)
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
+
+    // Check that error is what we expect.  This happens to be how data with all zeros fails to deserialize.
+    assert_custom_error!(err, RuleSetError::UnsupportedRuleSetRevMapVersion);
+}
+
+#[tokio::test]
+async fn validate_update_rule_state_state_pda_not_provided_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), Rule::Pass)
+        .unwrap();
+
+    // Put the RuleSet on chain.
+    let rule_set_addr =
+        create_rule_set_on_chain!(&mut context, rule_set, "test rule_set".to_string()).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new().pubkey();
+
+    let rule_authority = Keypair::new();
+
+    // Create a `validate` instruction with `update_rule_state` set to true.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint)
+        .payer(context.payer.pubkey())
+        .rule_authority(rule_authority.pubkey())
+        .additional_rule_accounts(vec![])
+        .build(ValidateArgs::V1 {
+            operation: Operation::OwnerTransfer.to_string(),
+            payload: Payload::default(),
+            update_rule_state: true,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![&rule_authority], None).await;
+
+    // Deconstruct the error code and make sure it is what we expect.
+    match err {
+        BanksClientError::TransactionError(TransactionError::InstructionError(0, err)) => {
+            assert_eq!(
+                ProgramError::try_from(err).unwrap_or_else(|_| panic!(
+                    "Could not convert InstructionError to ProgramError",
+                )),
+                ProgramError::NotEnoughAccountKeys,
+            );
+        }
+        _ => panic!("Unexpected error: {}", err),
+    }
 }

--- a/program/tests/write_to_buffer_account_and_data_checks.rs
+++ b/program/tests/write_to_buffer_account_and_data_checks.rs
@@ -4,23 +4,13 @@ pub mod utils;
 
 use mpl_token_auth_rules::{
     error::RuleSetError,
-    instruction::{
-        builders::{CreateOrUpdateBuilder, WriteToBufferBuilder},
-        CreateOrUpdateArgs, InstructionBuilder, WriteToBufferArgs,
-    },
-    payload::Payload,
+    instruction::{builders::WriteToBufferBuilder, InstructionBuilder, WriteToBufferArgs},
     state::{Rule, RuleSetV1},
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
-use solana_program::program_error::ProgramError;
-use solana_program::system_instruction;
-use solana_program_test::{tokio, BanksClientError};
-use solana_sdk::{
-    signature::Signer,
-    signer::keypair::Keypair,
-    transaction::{Transaction, TransactionError},
-};
+use solana_program_test::tokio;
+use solana_sdk::{signature::Signer, signer::keypair::Keypair, transaction::Transaction};
 use utils::{program_test, Operation};
 
 #[tokio::test]
@@ -79,4 +69,66 @@ async fn write_to_buffer_payer_not_signer_panics() {
         .banks_client
         .process_transaction(write_to_buffer_tx)
         .await;
+}
+
+#[tokio::test]
+async fn write_to_buffer_wrong_pda_fails() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // Get one partial chunk of the serialized `RuleSet`.
+    let serialized_rule_set_chunk = serialized_rule_set.chunks(100).next().unwrap();
+
+    // Find buffer PDA using WRONG creator for seed.
+    let wrong_creator = Keypair::new();
+    let (buffer_pda, _buffer_bump) =
+        mpl_token_auth_rules::pda::find_buffer_address(wrong_creator.pubkey());
+
+    // Create a `write_to_buffer` instruction.
+    let write_to_buffer_ix = WriteToBufferBuilder::new()
+        .payer(context.payer.pubkey())
+        .buffer_pda(buffer_pda)
+        .build(WriteToBufferArgs::V1 {
+            serialized_rule_set: serialized_rule_set_chunk.to_vec(),
+            overwrite: true,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let write_to_buffer_tx = Transaction::new_signed_with_payer(
+        &[write_to_buffer_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    let err = context
+        .banks_client
+        .process_transaction(write_to_buffer_tx)
+        .await
+        .expect_err("Write buffer should fail");
+
+    // Check that error is what we expect.
+    assert_custom_error!(err, RuleSetError::DerivedKeyInvalid);
 }

--- a/program/tests/write_to_buffer_account_and_data_checks.rs
+++ b/program/tests/write_to_buffer_account_and_data_checks.rs
@@ -1,0 +1,82 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod utils;
+
+use mpl_token_auth_rules::{
+    error::RuleSetError,
+    instruction::{
+        builders::{CreateOrUpdateBuilder, WriteToBufferBuilder},
+        CreateOrUpdateArgs, InstructionBuilder, WriteToBufferArgs,
+    },
+    payload::Payload,
+    state::{Rule, RuleSetV1},
+};
+use rmp_serde::Serializer;
+use serde::Serialize;
+use solana_program::program_error::ProgramError;
+use solana_program::system_instruction;
+use solana_program_test::{tokio, BanksClientError};
+use solana_sdk::{
+    signature::Signer,
+    signer::keypair::Keypair,
+    transaction::{Transaction, TransactionError},
+};
+use utils::{program_test, Operation};
+
+#[tokio::test]
+#[should_panic]
+async fn write_to_buffer_payer_not_signer_panics() {
+    let mut context = program_test().start_with_context().await;
+
+    // --------------------------------
+    // Create RuleSet
+    // --------------------------------
+    // Create some rules.
+    let adtl_signer = Rule::AdditionalSigner {
+        account: context.payer.pubkey(),
+    };
+
+    // Create a RuleSet.
+    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    rule_set
+        .add(Operation::OwnerTransfer.to_string(), adtl_signer)
+        .unwrap();
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_rule_set = Vec::new();
+    rule_set
+        .serialize(&mut Serializer::new(&mut serialized_rule_set))
+        .unwrap();
+
+    // Get one partial chunk of the serialized `RuleSet`.
+    let serialized_rule_set_chunk = serialized_rule_set.chunks(100).next().unwrap();
+
+    let (buffer_pda, _buffer_bump) =
+        mpl_token_auth_rules::pda::find_buffer_address(context.payer.pubkey());
+
+    // Create a `write_to_buffer` instruction.
+    let other_payer = Keypair::new();
+    let write_to_buffer_ix = WriteToBufferBuilder::new()
+        .payer(other_payer.pubkey())
+        .buffer_pda(buffer_pda)
+        .build(WriteToBufferArgs::V1 {
+            serialized_rule_set: serialized_rule_set_chunk.to_vec(),
+            overwrite: true,
+        })
+        .unwrap()
+        .instruction();
+
+    // Add it to a transaction.
+    let write_to_buffer_tx = Transaction::new_signed_with_payer(
+        &[write_to_buffer_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.  It will panic because of not enough signers.
+    let _result = context
+        .banks_client
+        .process_transaction(write_to_buffer_tx)
+        .await;
+}


### PR DESCRIPTION
### Notes
Adding tests that mostly check incoming accounts and data validation before logic occurs.  I think only `create_payer_not_signer_panics ` existed before this PR.  I put each of these instruction test suites in their own file.

#### create_account_and_data_checks.rs
```
running 9 tests
test create_payer_not_signer_panics - should panic ... ok
test create_rule_set_buffer_with_different_name_fails ... ok
test create_rule_set_to_wallet_fails ... ok
test create_rule_set_name_too_long_fails ... ok
test create_rule_set_to_wrong_pda_fails ... ok
test create_rule_set_wrong_owner_fails ... ok
test create_rule_set_empty_rule_set_fails ... ok
test create_rule_set_empty_buffer_fails ... ok
test create_rule_set_partial_buffer_fails ... ok
```

#### validate_account_and_data_checks.rs
```
running 10 tests
test validate_rule_set_with_wallet_fails ... ok
test validate_rule_set_with_uninitialized_pda_fails ... ok
test validate_rule_set_with_zero_data_fails ... ok
test validate_update_rule_state_payer_not_signer_panics - should panic ... ok
test validate_rule_set_with_incorrect_data_fails ... ok
test validate_update_rule_state_payer_not_provided_fails ... ok
test validate_update_rule_state_wrong_state_pda_fails ... ok
test validate_update_rule_state_incorrect_auth ... ok
test validate_update_rule_state_missing_auth ... ok
test validate_update_rule_state_state_pda_not_provided_fails ... ok
```

#### write_to_buffer_account_and_data_checks.rs
```
running 2 tests
test write_to_buffer_payer_not_signer_panics - should panic ... ok
test write_to_buffer_wrong_pda_fails ... ok
```