### PR TITLE
Use Vec to store duplicate Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ use mpl_token_auth_rules::{
         CreateOrUpdateArgs, InstructionBuilder, ValidateArgs,
     },
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use num_derive::ToPrimitive;
 use rmp_serde::Serializer;
@@ -146,7 +146,7 @@ fn main() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), payer.pubkey());
     rule_set
         .add(Operation::OwnerTransfer.to_string(), overall_rule)
         .unwrap();

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,6 +1,6 @@
 //! All structures and related functions representing a Rule Set on-chain.
 //!
-//! Key types include the main `RuleSetV1` type which keeps the the map of operations to `Rules`,
+//! Key types include the main `RuleSetV2` type which keeps the the map of operations to `Rules`,
 //! as well as `RuleSetHeader` and `RuleSetRevisionMapV1` types used to manage data within the
 //! `RuleSet` PDA.
 //!

--- a/program/src/state/rule_set.rs
+++ b/program/src/state/rule_set.rs
@@ -13,8 +13,10 @@ use std::collections::HashMap;
 /// Version of the `RuleSetRevisionMapV1` struct.
 pub const RULE_SET_REV_MAP_VERSION: u8 = 1;
 
-/// Version of the `RuleSetV1` struct.
-pub const RULE_SET_LIB_VERSION: u8 = 1;
+/// Version of the `RuleSetV2` struct.
+pub const RULE_SET_LIB_VERSION_1: u8 = 1;
+/// Version of the `RuleSetV2` struct.
+pub const RULE_SET_LIB_VERSION_2: u8 = 2;
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 /// Header used to keep track of where RuleSets are stored in the PDA.  This header is meant
@@ -63,17 +65,68 @@ pub struct RuleSetV1 {
     owner: Pubkey,
     /// Name of the RuleSet, used in PDA derivation.
     rule_set_name: String,
+    /// A map to determine the `Rule` that belongs to a given `Operation`.
+    pub operations: HashMap<String, Rule>,
+}
+
+impl RuleSetV1 {
+    /// Get the name of the `RuleSet`.
+    pub fn name(&self) -> &str {
+        &self.rule_set_name
+    }
+
+    /// Get the version of the `RuleSet`.
+    pub fn lib_version(&self) -> u8 {
+        self.lib_version
+    }
+
+    /// Get the owner of the `RuleSet`.
+    pub fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+
+    /// Add a key-value pair into a `RuleSet`.  If this key is already in the `RuleSet`
+    /// nothing is updated and an error is returned.
+    pub fn add(&mut self, operation: String, rule: Rule) -> ProgramResult {
+        if self.operations.get(&operation).is_none() {
+            self.operations.insert(operation, rule);
+            Ok(())
+        } else {
+            Err(RuleSetError::ValueOccupied.into())
+        }
+    }
+
+    /// Retrieve the `Rule` tree for a given `Operation`.
+    pub fn get(&self, operation: String) -> Option<&Rule> {
+        self.operations.get(&operation)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+/// The struct containing all Rule Set data, most importantly the map of operations to `Rules`.
+///  See top-level module for description of PDA memory layout.
+pub struct RuleSetV2 {
+    /// Version of the RuleSet.  This is not a user version, but the version
+    /// of this lib, to make sure that a `RuleSet` passed into our handlers
+    /// is one we are compatible with.
+    lib_version: u8,
+    /// Owner (creator) of the RuleSet.
+    #[cfg_attr(feature = "serde-with-feature", serde(with = "As::<DisplayFromStr>"))]
+    owner: Pubkey,
+    /// Name of the RuleSet, used in PDA derivation.
+    rule_set_name: String,
     /// A map to determine the index of the `Rule` that belongs to a given `Operation`.
     pub operations: HashMap<String, usize>,
     /// A Vec containing the unique `Rules`.
     rules: Vec<Rule>,
 }
 
-impl RuleSetV1 {
+impl RuleSetV2 {
     /// Create a new empty `RuleSet`.
     pub fn new(rule_set_name: String, owner: Pubkey) -> Self {
         Self {
-            lib_version: RULE_SET_LIB_VERSION,
+            lib_version: RULE_SET_LIB_VERSION_2,
             rule_set_name,
             owner,
             operations: HashMap::new(),

--- a/program/tests/additional_signer.rs
+++ b/program/tests/additional_signer.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::Payload,
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
@@ -27,7 +27,7 @@ async fn test_additional_signer() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/all.rs
+++ b/program/tests/all.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use solana_program::instruction::AccountMeta;
 use solana_program_test::tokio;
@@ -37,7 +37,7 @@ async fn test_all() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/amount.rs
+++ b/program/tests/amount.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -60,7 +60,7 @@ async fn parametric_amount_check(
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/any.rs
+++ b/program/tests/any.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -35,7 +35,7 @@ async fn test_any() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use solana_program::{instruction::InstructionError, pubkey, pubkey::Pubkey};
 use solana_program_test::{tokio, ProgramTestContext};
@@ -160,9 +160,9 @@ fn get_composed_rules() -> ComposedRules {
     }
 }
 
-fn get_royalty_rule_set(owner: Pubkey) -> RuleSetV1 {
+fn get_royalty_rule_set(owner: Pubkey) -> RuleSetV2 {
     // Create a RuleSet.
-    let mut royalty_rule_set = RuleSetV1::new(RULE_SET_NAME.to_string(), owner);
+    let mut royalty_rule_set = RuleSetV2::new(RULE_SET_NAME.to_string(), owner);
 
     // Get transfer and wallet-to-wallet rules.
     let rules = get_composed_rules();
@@ -505,7 +505,7 @@ async fn prog_owned_to_prog_owned() {
     assert_eq!(mpl_token_auth_rules::ID, first_on_chain_account.owner);
 
     // Create destination `RuleSet`.
-    let second_rule_set = RuleSetV1::new("second_rule_set".to_string(), context.payer.pubkey());
+    let second_rule_set = RuleSetV2::new("second_rule_set".to_string(), context.payer.pubkey());
 
     let second_rule_set_addr =
         create_rule_set_on_chain!(&mut context, second_rule_set, "second_rule_set".to_string())

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -22,7 +22,6 @@ use utils::{
     MetadataDelegateRole, Operation, PayloadKey, TokenDelegateRole, TransferScenario,
 };
 
-const ADDITIONAL_COMPUTE: u32 = 1_000_000;
 const RULE_SET_NAME: &str = "Metaplex Royalty RuleSet Dev";
 
 // --------------------------------
@@ -339,7 +338,7 @@ async fn create_royalty_rule_set(context: &mut ProgramTestContext) -> Pubkey {
         context,
         royalty_rule_set.clone(),
         RULE_SET_NAME.to_string(),
-        Some(ADDITIONAL_COMPUTE)
+        None
     )
     .await
 }
@@ -397,9 +396,7 @@ async fn wallet_to_wallet_unimplemented() {
         .instruction();
 
     // Validate fail operation.
-    let err =
-        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
-            .await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.  The `IsWallet` rule currently returns `NotImplemented`.
     match err {
@@ -479,7 +476,7 @@ async fn wallet_to_prog_owned() {
         .instruction();
 
     // Validate operation.
-    process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 }
 
 #[tokio::test]
@@ -568,7 +565,7 @@ async fn prog_owned_to_prog_owned() {
         .instruction();
 
     // Validate operation.
-    process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 }
 
 #[tokio::test]
@@ -638,7 +635,7 @@ async fn prog_owned_to_wallet() {
         .instruction();
 
     // Validate operation.
-    process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 }
 
 #[tokio::test]
@@ -709,9 +706,7 @@ async fn wrong_amount_fails() {
         .instruction();
 
     // Fail to validate operation.
-    let err =
-        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
-            .await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.  Amount was greater than that allowed in the rule so it
     // failed.
@@ -807,9 +802,7 @@ async fn prog_owner_not_on_list_fails() {
         .instruction();
 
     // Fail to validate operation.
-    let err =
-        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
-            .await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.  Program owner was not on the allow list.
     match err {
@@ -905,9 +898,7 @@ async fn prog_owned_but_zero_data_length() {
         .instruction();
 
     // Fail to validate operation.
-    let err =
-        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
-            .await;
+    let err = process_failing_validate_ix!(&mut context, validate_ix, vec![], None).await;
 
     // Check that error is what we expect.  Although the program owner is correct the data length is zero
     // so it fails the rule.

--- a/program/tests/buffered_rule_set.rs
+++ b/program/tests/buffered_rule_set.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1, RULE_SET_SERIALIZED_HEADER_LEN},
+    state::{Rule, RuleSetV2, RULE_SET_SERIALIZED_HEADER_LEN},
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
@@ -31,7 +31,7 @@ async fn buffered_rule_set() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/composed_rule.rs
+++ b/program/tests/composed_rule.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 
 use solana_program::instruction::AccountMeta;
@@ -50,7 +50,7 @@ async fn composed_rule() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/create_account_and_data_checks.rs
+++ b/program/tests/create_account_and_data_checks.rs
@@ -8,7 +8,7 @@ use mpl_token_auth_rules::{
         builders::{CreateOrUpdateBuilder, WriteToBufferBuilder},
         CreateOrUpdateArgs, InstructionBuilder, WriteToBufferArgs,
     },
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
@@ -29,7 +29,7 @@ async fn create_payer_not_signer_panics() {
 
     // Create a RuleSet.
     let other_payer = Keypair::new();
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), other_payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), other_payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -87,7 +87,7 @@ async fn create_rule_set_empty_buffer_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -163,7 +163,7 @@ async fn create_rule_set_partial_buffer_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -310,7 +310,7 @@ async fn create_rule_set_name_too_long_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new(
+    let mut rule_set = RuleSetV2::new(
         "test rule_set that has too long of a name".to_string(),
         context.payer.pubkey(),
     );
@@ -383,7 +383,7 @@ async fn create_rule_set_wrong_owner_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), Keypair::new().pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), Keypair::new().pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -451,7 +451,7 @@ async fn create_rule_set_buffer_with_different_name_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -558,7 +558,7 @@ async fn create_rule_set_to_wallet_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -620,7 +620,7 @@ async fn create_rule_set_to_wrong_pda_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/frequency.rs
+++ b/program/tests/frequency.rs
@@ -7,7 +7,7 @@ use mpl_token_auth_rules::{
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::Payload,
     pda::find_rule_set_state_address,
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
@@ -29,7 +29,7 @@ async fn test_frequency() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/is_wallet.rs
+++ b/program/tests/is_wallet.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{instruction::AccountMeta, signature::Signer, signer::keypair::Keypair};
@@ -25,7 +25,7 @@ async fn is_wallet() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/multiple_operations.rs
+++ b/program/tests/multiple_operations.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{instruction::AccountMeta, signature::Signer, signer::keypair::Keypair};
@@ -32,7 +32,7 @@ async fn correct_rule_used_for_each_operation() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
 
     // Use different rules for each operation.
     rule_set

--- a/program/tests/not.rs
+++ b/program/tests/not.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{CompareOp, Rule, RuleSetV1},
+    state::{CompareOp, Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -30,7 +30,7 @@ async fn test_not() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/pass.rs
+++ b/program/tests/pass.rs
@@ -5,7 +5,7 @@ pub mod utils;
 use mpl_token_auth_rules::{
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::Payload,
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -22,7 +22,7 @@ async fn test_pass() {
     let pass_rule = Rule::Pass;
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/pda_match.rs
+++ b/program/tests/pda_match.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType, SeedsVec},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program::{instruction::AccountMeta, pubkey::Pubkey};
 use solana_program_test::tokio;
@@ -28,7 +28,7 @@ async fn test_pda_match_assumed_owner() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -147,7 +147,7 @@ async fn test_pda_match_specified_owner() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/program_owned.rs
+++ b/program/tests/program_owned.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{
@@ -29,7 +29,7 @@ async fn program_owned() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/program_owned_list.rs
+++ b/program/tests/program_owned_list.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{
@@ -29,7 +29,7 @@ async fn program_owned_list() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/program_owned_set.rs
+++ b/program/tests/program_owned_set.rs
@@ -8,7 +8,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{
@@ -31,7 +31,7 @@ async fn program_owned_set() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/program_owned_tree.rs
+++ b/program/tests/program_owned_tree.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{
@@ -36,7 +36,7 @@ async fn program_owned_tree() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/pubkey_list_match.rs
+++ b/program/tests/pubkey_list_match.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -30,7 +30,7 @@ async fn test_pubkey_list_match() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/pubkey_match.rs
+++ b/program/tests/pubkey_match.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -28,7 +28,7 @@ async fn test_pubkey_match() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/pubkey_tree_match.rs
+++ b/program/tests/pubkey_tree_match.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType, ProofInfo},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use solana_program::pubkey::Pubkey;
 use solana_program_test::tokio;
@@ -35,7 +35,7 @@ async fn pubkey_tree_match() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/updated_rule_set.rs
+++ b/program/tests/updated_rule_set.rs
@@ -8,7 +8,7 @@ use mpl_token_auth_rules::{
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::{Payload, PayloadType},
     state::{
-        CompareOp, Rule, RuleSetHeader, RuleSetRevisionMapV1, RuleSetV1, RULE_SET_LIB_VERSION,
+        CompareOp, Rule, RuleSetHeader, RuleSetRevisionMapV1, RuleSetV2, RULE_SET_LIB_VERSION_2,
         RULE_SET_REV_MAP_VERSION, RULE_SET_SERIALIZED_HEADER_LEN,
     },
 };
@@ -32,7 +32,7 @@ async fn test_update_ruleset_data_integrity() {
     let first_overall_rule = Rule::Pass;
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -74,7 +74,7 @@ async fn test_update_ruleset_data_integrity() {
     };
 
     // Create a new RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Delegate {
@@ -128,7 +128,7 @@ async fn test_update_ruleset_data_integrity() {
     };
 
     // Create a new RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -154,7 +154,7 @@ async fn test_update_ruleset_data_integrity() {
     // Create RuleSet 3 and update on chain
     // --------------------------------
     // Create a new RuleSet reusing some previous rules.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -198,7 +198,7 @@ async fn test_update_ruleset_data_integrity() {
     // Create RuleSet 4 and update on chain
     // --------------------------------
     // Create a new RuleSet reusing some previous rules.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -239,7 +239,7 @@ async fn test_update_ruleset_data_integrity() {
 
         // Check the nth `RuleSet` lib version.
         assert_eq!(
-            data[rule_set_version_loc], RULE_SET_LIB_VERSION,
+            data[rule_set_version_loc], RULE_SET_LIB_VERSION_2,
             "The buffer doesn't match rule set {} lib version,",
             n
         );
@@ -318,7 +318,7 @@ async fn test_unknown_rule_set_revision_fails() {
     };
 
     // Create a RuleSet.
-    let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut first_rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     first_rule_set
         .add(
             Operation::Transfer {
@@ -344,7 +344,7 @@ async fn test_unknown_rule_set_revision_fails() {
     };
 
     // Create a new RuleSet.
-    let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut second_rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     second_rule_set
         .add(
             Operation::Transfer {
@@ -415,7 +415,7 @@ async fn test_correct_rule_set_is_used_after_update() {
     };
 
     // Create a RuleSet.
-    let mut first_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut first_rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     first_rule_set
         .add(
             Operation::Transfer {
@@ -441,7 +441,7 @@ async fn test_correct_rule_set_is_used_after_update() {
     };
 
     // Create a new RuleSet.
-    let mut second_rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut second_rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     second_rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -4,7 +4,7 @@ use mpl_token_auth_rules::{
         CreateOrUpdateArgs, InstructionBuilder, PuffRuleSetArgs, WriteToBufferArgs,
     },
     payload::ProofInfo,
-    state::RuleSetV1,
+    state::RuleSetV2,
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
@@ -206,7 +206,7 @@ macro_rules! create_rule_set_on_chain {
 
 pub async fn create_rule_set_on_chain_with_loc(
     context: &mut ProgramTestContext,
-    rule_set: RuleSetV1,
+    rule_set: RuleSetV2,
     rule_set_name: String,
     file: &str,
     line: u32,
@@ -277,7 +277,7 @@ macro_rules! create_big_rule_set_on_chain {
 
 pub async fn create_big_rule_set_on_chain_with_loc(
     context: &mut ProgramTestContext,
-    rule_set: RuleSetV1,
+    rule_set: RuleSetV2,
     rule_set_name: String,
     compute_budget: Option<u32>,
     file: &str,

--- a/program/tests/validate_account_and_data_checks.rs
+++ b/program/tests/validate_account_and_data_checks.rs
@@ -6,7 +6,7 @@ use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
     payload::Payload,
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 
 use solana_program::program_error::ProgramError;
@@ -25,7 +25,7 @@ async fn validate_update_rule_state_payer_not_signer_panics() {
     let mut context = program_test().start_with_context().await;
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -90,7 +90,7 @@ async fn validate_update_rule_state_payer_not_provided_fails() {
     let mut context = program_test().start_with_context().await;
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -330,7 +330,7 @@ async fn validate_update_rule_state_wrong_state_pda_fails() {
     let mut context = program_test().start_with_context().await;
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -391,7 +391,7 @@ async fn validate_update_rule_state_state_pda_not_provided_fails() {
     let mut context = program_test().start_with_context().await;
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -459,7 +459,7 @@ async fn validate_update_rule_state_incorrect_auth() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -522,7 +522,7 @@ async fn validate_update_rule_state_missing_auth() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {

--- a/program/tests/write_to_buffer_account_and_data_checks.rs
+++ b/program/tests/write_to_buffer_account_and_data_checks.rs
@@ -5,7 +5,7 @@ pub mod utils;
 use mpl_token_auth_rules::{
     error::RuleSetError,
     instruction::{builders::WriteToBufferBuilder, InstructionBuilder, WriteToBufferArgs},
-    state::{Rule, RuleSetV1},
+    state::{Rule, RuleSetV2},
 };
 use rmp_serde::Serializer;
 use serde::Serialize;
@@ -27,7 +27,7 @@ async fn write_to_buffer_payer_not_signer_panics() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {
@@ -90,7 +90,7 @@ async fn write_to_buffer_wrong_pda_fails() {
     };
 
     // Create a RuleSet.
-    let mut rule_set = RuleSetV1::new("test rule_set".to_string(), context.payer.pubkey());
+    let mut rule_set = RuleSetV2::new("test rule_set".to_string(), context.payer.pubkey());
     rule_set
         .add(
             Operation::Transfer {


### PR DESCRIPTION
This looks like it is working to make compute small.  Saves one copy of duplicate lists, allows me to lower basic royalty ruleset test to default 200k

It is buiilt on top of Keith's PR that uses all the additional delegate types and adds 11 accounts to each rule