### PR TITLE
Namespacing operations.

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -13,8 +13,8 @@ use crate::{
         RULE_SET_REV_MAP_VERSION, RULE_SET_SERIALIZED_HEADER_LEN,
     },
     utils::{
-        assert_derivation, create_or_allocate_account_raw, get_existing_revision_map, is_zeroed,
-        resize_or_reallocate_account_raw,
+        assert_derivation, create_or_allocate_account_raw, get_existing_revision_map,
+        get_operation, is_zeroed, resize_or_reallocate_account_raw,
     },
     MAX_NAME_LENGTH,
 };
@@ -366,9 +366,7 @@ fn validate_v1(program_id: &Pubkey, ctx: Context<Validate>, args: ValidateArgs) 
         .collect::<HashMap<Pubkey, &AccountInfo>>();
 
     // Get the `Rule` from the `RuleSet` based on the user-specified operation.
-    let rule = rule_set
-        .get(operation)
-        .ok_or(RuleSetError::OperationNotFound)?;
+    let rule = get_operation(operation, &rule_set)?;
 
     // Validate the `Rule`.
     if let Err(err) = rule.validate(

--- a/program/src/state/rules.rs
+++ b/program/src/state/rules.rs
@@ -195,6 +195,8 @@ pub enum Rule {
         /// The field in the `Payload` to be compared.
         field: String,
     },
+    /// A rule that tells the operation finder to use the default namespace rule.
+    Namespace,
 }
 
 impl Rule {
@@ -626,15 +628,21 @@ impl Rule {
                     (false, self.to_error())
                 }
             }
+            Rule::Namespace => {
+                msg!("Validating Namespace");
+                (false, self.to_error())
+            }
         }
     }
 
     /// Convert the rule to a corresponding error resulting from the rule failure.
     pub fn to_error(&self) -> ProgramError {
         match self {
-            Rule::All { .. } | Rule::Any { .. } | Rule::Not { .. } | Rule::Pass => {
-                RuleSetError::UnexpectedRuleSetFailure.into()
-            }
+            Rule::All { .. }
+            | Rule::Any { .. }
+            | Rule::Not { .. }
+            | Rule::Pass
+            | Rule::Namespace => RuleSetError::UnexpectedRuleSetFailure.into(),
             Rule::AdditionalSigner { .. } => RuleSetError::AdditionalSignerCheckFailed.into(),
             Rule::PubkeyMatch { .. } => RuleSetError::PubkeyMatchCheckFailed.into(),
             Rule::PubkeyListMatch { .. } => RuleSetError::PubkeyListMatchCheckFailed.into(),

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -223,23 +223,21 @@ pub fn is_zeroed(buf: &[u8]) -> bool {
     }
 }
 
-/// Gets the operation using namespaces.
+/// This function returns the rule for an operation by recursively searching through fallbacks
 pub fn get_operation(operation: String, rule_set: &RuleSetV1) -> Result<&Rule, ProgramError> {
     let rule = rule_set.get(operation.to_string());
 
     match rule {
-        Some(rule) => {
-            msg!("Found Operation: {:?}", operation);
-            Ok(rule)
-        }
+        // This operation exists, return it.
+        Some(rule) => Ok(rule),
         None => {
+            // Check for a ':' namespace separator. If it exists try to operation namespace to see if
+            // a fallback exists. E.g. 'transfer:owner' will check for a fallback for 'transfer'.
+            // If it doesn't exist then fail.
             let split = operation.split(':').collect::<Vec<&str>>();
             if split.len() > 1 {
-                msg!("Can't Find Operation: {:?}", operation);
-                msg!("Looking for: {:?}", split[0]);
                 get_operation(split[0].to_owned(), rule_set)
             } else {
-                msg!("Operation Not Found: {:?}", operation);
                 Err(RuleSetError::OperationNotFound.into())
             }
         }

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -228,9 +228,7 @@ pub fn get_operation(operation: String, rule_set: &RuleSetV1) -> Result<&Rule, P
     let rule = rule_set.get(operation.to_string());
 
     match rule {
-        // This operation exists, return it.
-        Some(rule) => Ok(rule),
-        None => {
+        Some(Rule::Namespace) => {
             // Check for a ':' namespace separator. If it exists try to operation namespace to see if
             // a fallback exists. E.g. 'transfer:owner' will check for a fallback for 'transfer'.
             // If it doesn't exist then fail.
@@ -241,5 +239,7 @@ pub fn get_operation(operation: String, rule_set: &RuleSetV1) -> Result<&Rule, P
                 Err(RuleSetError::OperationNotFound.into())
             }
         }
+        Some(r) => Ok(r),
+        None => Err(RuleSetError::OperationNotFound.into()),
     }
 }

--- a/program/tests/namespace_royalty_enforcement.rs
+++ b/program/tests/namespace_royalty_enforcement.rs
@@ -18,11 +18,11 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
 };
 use utils::{
-    create_associated_token_account, create_mint, program_test, DelegateScenario,
-    MetadataDelegateRole, Operation, PayloadKey, TokenDelegateRole, TransferScenario,
+    create_associated_token_account, create_mint, program_test, DelegateScenario, Operation,
+    PayloadKey, TokenDelegateRole, TransferScenario,
 };
 
-const ADDITIONAL_COMPUTE: u32 = 1_000_000;
+const ADDITIONAL_COMPUTE: u32 = 230_000;
 const RULE_SET_NAME: &str = "Metaplex Royalty RuleSet Dev";
 
 // --------------------------------
@@ -171,49 +171,14 @@ fn get_royalty_rule_set(owner: Pubkey) -> RuleSetV1 {
     // --------------------------------
     // Set up transfer operations
     // --------------------------------
-    let transfer_owner_operation = Operation::Transfer {
-        scenario: TransferScenario::Holder,
-    };
-
-    let transfer_transfer_delegate_operation = Operation::Transfer {
-        scenario: TransferScenario::TransferDelegate,
-    };
-
-    let transfer_sale_delegate_operation = Operation::Transfer {
-        scenario: TransferScenario::SaleDelegate,
-    };
-
-    let transfer_migration_delegate_operation = Operation::Transfer {
-        scenario: TransferScenario::MigrationDelegate,
-    };
+    let transfer_operation = Operation::TransferNamespace;
 
     let transfer_wallet_to_wallet_operation = Operation::Transfer {
         scenario: TransferScenario::WalletToWallet,
     };
 
     royalty_rule_set
-        .add(
-            transfer_owner_operation.to_string(),
-            rules.transfer_rule.clone(),
-        )
-        .unwrap();
-    royalty_rule_set
-        .add(
-            transfer_transfer_delegate_operation.to_string(),
-            rules.transfer_rule.clone(),
-        )
-        .unwrap();
-    royalty_rule_set
-        .add(
-            transfer_sale_delegate_operation.to_string(),
-            rules.transfer_rule.clone(),
-        )
-        .unwrap();
-    royalty_rule_set
-        .add(
-            transfer_migration_delegate_operation.to_string(),
-            rules.transfer_rule,
-        )
+        .add(transfer_operation.to_string(), rules.transfer_rule.clone())
         .unwrap();
     royalty_rule_set
         .add(
@@ -223,84 +188,17 @@ fn get_royalty_rule_set(owner: Pubkey) -> RuleSetV1 {
         .unwrap();
 
     // --------------------------------
-    // Setup metadata delegate operations
+    // Setup delegate operations
     // --------------------------------
-    let metadata_delegate_authority_operation = Operation::Delegate {
-        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Authority),
-    };
-
-    let metadata_delegate_collection_operation = Operation::Delegate {
-        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Collection),
-    };
-
-    let metadata_delegate_use_operation = Operation::Delegate {
-        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Use),
-    };
-
-    let metadata_delegate_update_operation = Operation::Delegate {
-        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Update),
-    };
+    let delegate_operation = Operation::DelegateNamespace;
 
     royalty_rule_set
-        .add(
-            metadata_delegate_authority_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
+        .add(delegate_operation.to_string(), rules.delegate_rule.clone())
         .unwrap();
-    royalty_rule_set
-        .add(
-            metadata_delegate_collection_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
-        .unwrap();
-    royalty_rule_set
-        .add(
-            metadata_delegate_use_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
-        .unwrap();
-    royalty_rule_set
-        .add(
-            metadata_delegate_update_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
-        .unwrap();
-
-    // --------------------------------
-    // Setup token delegate operations
-    // --------------------------------
-    let token_delegate_sale_operation = Operation::Delegate {
-        scenario: DelegateScenario::Token(TokenDelegateRole::Sale),
-    };
-
-    let token_delegate_transfer_operation = Operation::Delegate {
-        scenario: DelegateScenario::Token(TokenDelegateRole::Transfer),
-    };
 
     let token_delegate_locked_transfer_operation = Operation::Delegate {
         scenario: DelegateScenario::Token(TokenDelegateRole::LockedTransfer),
     };
-
-    let token_delegate_utility_operation = Operation::Delegate {
-        scenario: DelegateScenario::Token(TokenDelegateRole::Utility),
-    };
-
-    let token_delegate_staking_operation = Operation::Delegate {
-        scenario: DelegateScenario::Token(TokenDelegateRole::Staking),
-    };
-
-    royalty_rule_set
-        .add(
-            token_delegate_sale_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
-        .unwrap();
-    royalty_rule_set
-        .add(
-            token_delegate_transfer_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
-        .unwrap();
 
     // --------------------------------
     // NOTE THIS IS THE ONLY OPERATION
@@ -314,19 +212,7 @@ fn get_royalty_rule_set(owner: Pubkey) -> RuleSetV1 {
         )
         .unwrap();
 
-    royalty_rule_set
-        .add(
-            token_delegate_utility_operation.to_string(),
-            rules.delegate_rule.clone(),
-        )
-        .unwrap();
-
-    royalty_rule_set
-        .add(
-            token_delegate_staking_operation.to_string(),
-            rules.delegate_rule,
-        )
-        .unwrap();
+    println!("Royalty Rule Set: {:#?}", royalty_rule_set);
 
     royalty_rule_set
 }

--- a/program/tests/namespace_royalty_enforcement.rs
+++ b/program/tests/namespace_royalty_enforcement.rs
@@ -1,0 +1,922 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod utils;
+
+use mpl_token_auth_rules::{
+    error::RuleSetError,
+    instruction::{builders::ValidateBuilder, InstructionBuilder, ValidateArgs},
+    payload::{Payload, PayloadType},
+    state::{CompareOp, Rule, RuleSetV1},
+};
+use solana_program::{instruction::InstructionError, pubkey, pubkey::Pubkey};
+use solana_program_test::{tokio, ProgramTestContext};
+use solana_sdk::{
+    instruction::AccountMeta,
+    signature::Signer,
+    signer::keypair::Keypair,
+    system_instruction,
+    transaction::{Transaction, TransactionError},
+};
+use utils::{
+    create_associated_token_account, create_mint, program_test, DelegateScenario,
+    MetadataDelegateRole, Operation, PayloadKey, TokenDelegateRole, TransferScenario,
+};
+
+const ADDITIONAL_COMPUTE: u32 = 1_000_000;
+const RULE_SET_NAME: &str = "Metaplex Royalty RuleSet Dev";
+
+// --------------------------------
+// Define Program Allow List
+// --------------------------------
+const ROOSTER_PROGRAM_ID: Pubkey = pubkey!("Roostrnex2Z9Y2XZC49sFAdZARP8E4iFpEnZC5QJWdz");
+const TOKEN_METADATA_PROGRAM_ID: Pubkey = pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+const TOKEN_AUTH_RULES_ID: Pubkey = pubkey!("auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg");
+
+const TRANSFER_PROGRAM_BASE_ALLOW_LIST: [Pubkey; 3] = [
+    TOKEN_METADATA_PROGRAM_ID,
+    ROOSTER_PROGRAM_ID,
+    TOKEN_AUTH_RULES_ID,
+];
+const DELEGATE_PROGRAM_BASE_ALLOW_LIST: [Pubkey; 3] = [
+    TOKEN_METADATA_PROGRAM_ID,
+    ROOSTER_PROGRAM_ID,
+    TOKEN_AUTH_RULES_ID,
+];
+const ADVANCED_DELEGATE_PROGRAM_BASE_ALLOW_LIST: [Pubkey; 3] = [
+    TOKEN_METADATA_PROGRAM_ID,
+    ROOSTER_PROGRAM_ID,
+    TOKEN_AUTH_RULES_ID,
+];
+
+struct ComposedRules {
+    transfer_rule: Rule,
+    wallet_to_wallet_rule: Rule,
+    delegate_rule: Rule,
+    advanced_delegate_rule: Rule,
+}
+
+// Get the four Composed Rules used in this RuleSet.
+fn get_composed_rules() -> ComposedRules {
+    // --------------------------------
+    // Create Primitive Rules
+    // --------------------------------
+    let nft_amount = Rule::Amount {
+        field: PayloadKey::Amount.to_string(),
+        amount: 1,
+        operator: CompareOp::Eq,
+    };
+
+    // Generate some random programs to add to the base lists.
+    let random_programs = (0..8).map(|_| Keypair::new().pubkey()).collect::<Vec<_>>();
+
+    let source_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
+        field: PayloadKey::Source.to_string(),
+    };
+
+    let dest_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
+        field: PayloadKey::Destination.to_string(),
+    };
+
+    let authority_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
+        field: PayloadKey::Authority.to_string(),
+    };
+
+    let source_is_wallet = Rule::IsWallet {
+        field: PayloadKey::Source.to_string(),
+    };
+
+    let dest_is_wallet = Rule::IsWallet {
+        field: PayloadKey::Destination.to_string(),
+    };
+
+    let delegate_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            DELEGATE_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
+        field: PayloadKey::Delegate.to_string(),
+    };
+
+    let advanced_delegate_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            ADVANCED_DELEGATE_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs,
+        ]
+        .concat(),
+        field: PayloadKey::Delegate.to_string(),
+    };
+
+    // --------------------------------
+    // Create Composed Rules from
+    // Primitive Rules
+    // --------------------------------
+    // amount is 1 && (source owner on allow list || dest owner on allow list || authority owner on allow list )
+    let transfer_rule = Rule::All {
+        rules: vec![
+            nft_amount.clone(),
+            Rule::Any {
+                rules: vec![
+                    source_program_allow_list,
+                    dest_program_allow_list,
+                    authority_program_allow_list,
+                ],
+            },
+        ],
+    };
+
+    // (amount is 1 && source is wallet && dest is wallet)
+    let wallet_to_wallet_rule = Rule::All {
+        rules: vec![nft_amount.clone(), source_is_wallet, dest_is_wallet],
+    };
+
+    let delegate_rule = Rule::All {
+        rules: vec![nft_amount.clone(), delegate_program_allow_list],
+    };
+
+    let advanced_delegate_rule = Rule::All {
+        rules: vec![nft_amount, advanced_delegate_program_allow_list],
+    };
+
+    ComposedRules {
+        transfer_rule,
+        wallet_to_wallet_rule,
+        delegate_rule,
+        advanced_delegate_rule,
+    }
+}
+
+fn get_royalty_rule_set(owner: Pubkey) -> RuleSetV1 {
+    // Create a RuleSet.
+    let mut royalty_rule_set = RuleSetV1::new(RULE_SET_NAME.to_string(), owner);
+
+    // Get transfer and wallet-to-wallet rules.
+    let rules = get_composed_rules();
+
+    // --------------------------------
+    // Set up transfer operations
+    // --------------------------------
+    let transfer_owner_operation = Operation::Transfer {
+        scenario: TransferScenario::Holder,
+    };
+
+    let transfer_transfer_delegate_operation = Operation::Transfer {
+        scenario: TransferScenario::TransferDelegate,
+    };
+
+    let transfer_sale_delegate_operation = Operation::Transfer {
+        scenario: TransferScenario::SaleDelegate,
+    };
+
+    let transfer_migration_delegate_operation = Operation::Transfer {
+        scenario: TransferScenario::MigrationDelegate,
+    };
+
+    let transfer_wallet_to_wallet_operation = Operation::Transfer {
+        scenario: TransferScenario::WalletToWallet,
+    };
+
+    royalty_rule_set
+        .add(
+            transfer_owner_operation.to_string(),
+            rules.transfer_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            transfer_transfer_delegate_operation.to_string(),
+            rules.transfer_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            transfer_sale_delegate_operation.to_string(),
+            rules.transfer_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            transfer_migration_delegate_operation.to_string(),
+            rules.transfer_rule,
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            transfer_wallet_to_wallet_operation.to_string(),
+            rules.wallet_to_wallet_rule,
+        )
+        .unwrap();
+
+    // --------------------------------
+    // Setup metadata delegate operations
+    // --------------------------------
+    let metadata_delegate_authority_operation = Operation::Delegate {
+        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Authority),
+    };
+
+    let metadata_delegate_collection_operation = Operation::Delegate {
+        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Collection),
+    };
+
+    let metadata_delegate_use_operation = Operation::Delegate {
+        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Use),
+    };
+
+    let metadata_delegate_update_operation = Operation::Delegate {
+        scenario: DelegateScenario::Metadata(MetadataDelegateRole::Update),
+    };
+
+    royalty_rule_set
+        .add(
+            metadata_delegate_authority_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            metadata_delegate_collection_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            metadata_delegate_use_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            metadata_delegate_update_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+
+    // --------------------------------
+    // Setup token delegate operations
+    // --------------------------------
+    let token_delegate_sale_operation = Operation::Delegate {
+        scenario: DelegateScenario::Token(TokenDelegateRole::Sale),
+    };
+
+    let token_delegate_transfer_operation = Operation::Delegate {
+        scenario: DelegateScenario::Token(TokenDelegateRole::Transfer),
+    };
+
+    let token_delegate_locked_transfer_operation = Operation::Delegate {
+        scenario: DelegateScenario::Token(TokenDelegateRole::LockedTransfer),
+    };
+
+    let token_delegate_utility_operation = Operation::Delegate {
+        scenario: DelegateScenario::Token(TokenDelegateRole::Utility),
+    };
+
+    let token_delegate_staking_operation = Operation::Delegate {
+        scenario: DelegateScenario::Token(TokenDelegateRole::Staking),
+    };
+
+    royalty_rule_set
+        .add(
+            token_delegate_sale_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+    royalty_rule_set
+        .add(
+            token_delegate_transfer_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+
+    // --------------------------------
+    // NOTE THIS IS THE ONLY OPERATION
+    // THAT USES THE ADVANCED DELEGATE
+    // RULE.
+    // --------------------------------
+    royalty_rule_set
+        .add(
+            token_delegate_locked_transfer_operation.to_string(),
+            rules.advanced_delegate_rule,
+        )
+        .unwrap();
+
+    royalty_rule_set
+        .add(
+            token_delegate_utility_operation.to_string(),
+            rules.delegate_rule.clone(),
+        )
+        .unwrap();
+
+    royalty_rule_set
+        .add(
+            token_delegate_staking_operation.to_string(),
+            rules.delegate_rule,
+        )
+        .unwrap();
+
+    royalty_rule_set
+}
+
+async fn create_royalty_rule_set(context: &mut ProgramTestContext) -> Pubkey {
+    let royalty_rule_set = get_royalty_rule_set(context.payer.pubkey());
+
+    // Put the `RuleSet` on chain.
+    create_big_rule_set_on_chain!(
+        context,
+        royalty_rule_set.clone(),
+        RULE_SET_NAME.to_string(),
+        Some(ADDITIONAL_COMPUTE)
+    )
+    .await
+}
+
+#[tokio::test]
+async fn create_rule_set() {
+    let mut context = program_test().start_with_context().await;
+    let _rule_set_addr = create_royalty_rule_set(&mut context).await;
+}
+
+#[tokio::test]
+async fn wallet_to_wallet_unimplemented() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Create source and destination wallets.
+    let source = Keypair::new();
+    let dest = Keypair::new();
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(dest.pubkey()),
+        ),
+    ]);
+
+    let transfer_wallet_to_wallet_operation = Operation::Transfer {
+        scenario: TransferScenario::WalletToWallet,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source.pubkey(), false),
+            AccountMeta::new_readonly(dest.pubkey(), false),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_wallet_to_wallet_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate fail operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
+            .await;
+
+    // Check that error is what we expect.  The `IsWallet` rule currently returns `NotImplemented`.
+    match err {
+        solana_program_test::BanksClientError::TransactionError(
+            TransactionError::InstructionError(_, InstructionError::Custom(error)),
+        ) => {
+            assert_eq!(error, RuleSetError::NotImplemented as u32);
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn wallet_to_prog_owned() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Source key is a wallet.
+    let source = Keypair::new();
+
+    // Our destination key is going to be an account owned by the mpl-token-auth-rules program.
+    // Any one will do so for convenience we just use the RuleSet.
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, on_chain_account.owner);
+
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_owner_operation = Operation::Transfer {
+        scenario: TransferScenario::Holder,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source.pubkey(), false),
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_owner_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate operation.
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+}
+
+#[tokio::test]
+async fn prog_owned_to_prog_owned() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Our source and destination keys are going to be accounts owned by the mpl-token-auth-rules
+    // program.  Any one will do so for convenience we just use two `RuleSets`.
+
+    // Get first on-chain account.
+    let first_on_chain_account = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(first_on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, first_on_chain_account.owner);
+
+    // Create destination `RuleSet`.
+    let second_rule_set = RuleSetV1::new("second_rule_set".to_string(), context.payer.pubkey());
+
+    let second_rule_set_addr =
+        create_rule_set_on_chain!(&mut context, second_rule_set, "second_rule_set".to_string())
+            .await;
+
+    // Get second on-chain account.
+    let second_on_chain_account = context
+        .banks_client
+        .get_account(second_rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(second_on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, second_on_chain_account.owner);
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(second_rule_set_addr),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_transfer_delegate_operation = Operation::Transfer {
+        scenario: TransferScenario::TransferDelegate,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(second_rule_set_addr, false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_transfer_delegate_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate operation.
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+}
+
+#[tokio::test]
+async fn prog_owned_to_wallet() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Our source key is going to be an account owned by the mpl-token-auth-rules program.  Any one
+    // will do so for convenience we just use the `RuleSet`.
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, on_chain_account.owner);
+
+    // Destination key is a wallet.
+    let dest = Keypair::new();
+
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_sale_delegate_operation = Operation::Transfer {
+        scenario: TransferScenario::SaleDelegate,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(dest.pubkey(), false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_sale_delegate_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Validate operation.
+    process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+}
+
+#[tokio::test]
+async fn wrong_amount_fails() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Our source key is going to be an account owned by the mpl-token-auth-rules program.  Any one
+    // will do so for convenience we just use the `RuleSet`.
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, on_chain_account.owner);
+
+    // Destination key is a wallet.
+    let dest = Keypair::new();
+
+    // Store the payload of data to validate against the rule definition, using the WRONG amount.
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(2)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(dest.pubkey()),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_sale_delegate_operation = Operation::Transfer {
+        scenario: TransferScenario::SaleDelegate,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(dest.pubkey(), false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_sale_delegate_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
+            .await;
+
+    // Check that error is what we expect.  Amount was greater than that allowed in the rule so it
+    // failed.
+    match err {
+        solana_program_test::BanksClientError::TransactionError(
+            TransactionError::InstructionError(_, InstructionError::Custom(error)),
+        ) => {
+            assert_eq!(error, RuleSetError::AmountCheckFailed as u32);
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn prog_owner_not_on_list_fails() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Source key is a wallet.
+    let source = Keypair::new();
+
+    // Create an associated token account for the sole purpose of having an account that is owned
+    // by a different program than what is in the rule.
+    create_mint(
+        &mut context,
+        &mint,
+        &source.pubkey(),
+        Some(&source.pubkey()),
+        0,
+    )
+    .await
+    .unwrap();
+
+    let associated_token_account =
+        create_associated_token_account(&mut context, &source, &mint.pubkey())
+            .await
+            .unwrap();
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(associated_token_account)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(spl_token::ID, on_chain_account.owner);
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(associated_token_account),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_owner_operation = Operation::Transfer {
+        scenario: TransferScenario::Holder,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source.pubkey(), false),
+            AccountMeta::new_readonly(associated_token_account, false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_owner_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
+            .await;
+
+    // Check that error is what we expect.  Program owner was not on the allow list.
+    match err {
+        solana_program_test::BanksClientError::TransactionError(
+            TransactionError::InstructionError(_, InstructionError::Custom(error)),
+        ) => {
+            assert_eq!(error, RuleSetError::ProgramOwnedListCheckFailed as u32);
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn prog_owned_but_zero_data_length() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr = create_royalty_rule_set(&mut context).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Source key is a wallet.
+    let source = Keypair::new();
+
+    // Create an account owned by mpl-token-auth-rules.
+    let program_owned_account = Keypair::new();
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[system_instruction::create_account(
+            &context.payer.pubkey(),
+            &program_owned_account.pubkey(),
+            rent.minimum_balance(0),
+            0,
+            &mpl_token_auth_rules::ID,
+        )],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &program_owned_account],
+        context.last_blockhash,
+    );
+
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(program_owned_account.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Verify data length is zero.
+    assert_eq!(0, on_chain_account.data.len());
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, on_chain_account.owner);
+
+    // Store the payload of data to validate against the rule definition.
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(program_owned_account.pubkey()),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_owner_operation = Operation::Transfer {
+        scenario: TransferScenario::Holder,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source.pubkey(), false),
+            AccountMeta::new_readonly(program_owned_account.pubkey(), false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_owner_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
+            .await;
+
+    // Check that error is what we expect.  Although the program owner is correct the data length is zero
+    // so it fails the rule.
+    match err {
+        solana_program_test::BanksClientError::TransactionError(
+            TransactionError::InstructionError(_, InstructionError::Custom(error)),
+        ) => {
+            assert_eq!(error, RuleSetError::ProgramOwnedListCheckFailed as u32);
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    }
+}

--- a/program/tests/namespace_royalty_enforcement.rs
+++ b/program/tests/namespace_royalty_enforcement.rs
@@ -371,6 +371,24 @@ async fn create_royalty_rule_set(context: &mut ProgramTestContext) -> Pubkey {
     .await
 }
 
+async fn create_incomplete_royalty_rule_set(
+    context: &mut ProgramTestContext,
+    missing_op: String,
+) -> Pubkey {
+    let mut royalty_rule_set = get_royalty_rule_set(context.payer.pubkey());
+    // Remove a namespaced operation to verify it fails.
+    royalty_rule_set.operations.remove(&missing_op);
+
+    // Put the `RuleSet` on chain.
+    create_big_rule_set_on_chain!(
+        context,
+        royalty_rule_set.clone(),
+        RULE_SET_NAME.to_string(),
+        Some(ADDITIONAL_COMPUTE)
+    )
+    .await
+}
+
 #[tokio::test]
 async fn create_rule_set() {
     let mut context = program_test().start_with_context().await;
@@ -507,6 +525,172 @@ async fn wallet_to_prog_owned() {
 
     // Validate operation.
     process_passing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE)).await;
+}
+
+#[tokio::test]
+async fn wallet_to_prog_owned_missing_namespace() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr =
+        create_incomplete_royalty_rule_set(&mut context, "Transfer:Owner".to_string()).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Source key is a wallet.
+    let source = Keypair::new();
+
+    // Our destination key is going to be an account owned by the mpl-token-auth-rules program.
+    // Any one will do so for convenience we just use the RuleSet.
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, on_chain_account.owner);
+
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_owner_operation = Operation::Transfer {
+        scenario: TransferScenario::Holder,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source.pubkey(), false),
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_owner_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
+            .await;
+
+    // Check that error is what we expect.  Program owner was not on the allow list.
+    match err {
+        solana_program_test::BanksClientError::TransactionError(
+            TransactionError::InstructionError(_, InstructionError::Custom(error)),
+        ) => {
+            assert_eq!(error, RuleSetError::OperationNotFound as u32);
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn wallet_to_prog_owned_no_default() {
+    let mut context = program_test().start_with_context().await;
+    let rule_set_addr =
+        create_incomplete_royalty_rule_set(&mut context, "Transfer".to_string()).await;
+
+    // Create a Keypair to simulate a token mint address.
+    let mint = Keypair::new();
+
+    // Source key is a wallet.
+    let source = Keypair::new();
+
+    // Our destination key is going to be an account owned by the mpl-token-auth-rules program.
+    // Any one will do so for convenience we just use the RuleSet.
+
+    // Get on-chain account.
+    let on_chain_account = context
+        .banks_client
+        .get_account(rule_set_addr)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Account must have nonzero data to count as program-owned.
+    assert!(on_chain_account.data.iter().any(|&x| x != 0));
+
+    // Verify account ownership.
+    assert_eq!(mpl_token_auth_rules::ID, on_chain_account.owner);
+
+    let payload = Payload::from([
+        (PayloadKey::Amount.to_string(), PayloadType::Number(1)),
+        (
+            PayloadKey::Source.to_string(),
+            PayloadType::Pubkey(source.pubkey()),
+        ),
+        (
+            PayloadKey::Destination.to_string(),
+            PayloadType::Pubkey(rule_set_addr),
+        ),
+        (
+            PayloadKey::Authority.to_string(),
+            PayloadType::Pubkey(context.payer.pubkey()),
+        ),
+    ]);
+
+    let transfer_owner_operation = Operation::Transfer {
+        scenario: TransferScenario::Holder,
+    };
+
+    // Create a `validate` instruction.
+    let validate_ix = ValidateBuilder::new()
+        .rule_set_pda(rule_set_addr)
+        .mint(mint.pubkey())
+        .additional_rule_accounts(vec![
+            AccountMeta::new_readonly(source.pubkey(), false),
+            AccountMeta::new_readonly(rule_set_addr, false),
+            AccountMeta::new_readonly(context.payer.pubkey(), true),
+        ])
+        .build(ValidateArgs::V1 {
+            operation: transfer_owner_operation.to_string(),
+            payload,
+            update_rule_state: false,
+            rule_set_revision: None,
+        })
+        .unwrap()
+        .instruction();
+
+    // Fail to validate operation.
+    let err =
+        process_failing_validate_ix!(&mut context, validate_ix, vec![], Some(ADDITIONAL_COMPUTE))
+            .await;
+
+    // Check that error is what we expect.  Program owner was not on the allow list.
+    match err {
+        solana_program_test::BanksClientError::TransactionError(
+            TransactionError::InstructionError(_, InstructionError::Custom(error)),
+        ) => {
+            assert_eq!(error, RuleSetError::OperationNotFound as u32);
+        }
+        _ => panic!("Unexpected error: {:?}", err),
+    }
 }
 
 #[tokio::test]

--- a/program/tests/namespace_royalty_enforcement.rs
+++ b/program/tests/namespace_royalty_enforcement.rs
@@ -24,7 +24,7 @@ use utils::{
     MetadataDelegateRole, Operation, PayloadKey, TokenDelegateRole, TransferScenario,
 };
 
-const ADDITIONAL_COMPUTE: u32 = 1_400_000;
+const ADDITIONAL_COMPUTE: u32 = 400_000;
 const RULE_SET_NAME: &str = "Metaplex Royalty RuleSet Dev";
 
 // --------------------------------
@@ -70,38 +70,32 @@ fn get_composed_rules() -> ComposedRules {
     };
 
     // Generate some random programs to add to the base lists.
-    let random_programs = (0..68).map(|_| Keypair::new().pubkey()).collect::<Vec<_>>();
+    let random_programs = (0..18).map(|_| Keypair::new().pubkey()).collect::<Vec<_>>();
 
-    let source_program_allow_list = Rule::ProgramOwnedSet {
-        programs: HashSet::from_iter(
-            [
-                TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
-                random_programs.clone(),
-            ]
-            .concat(),
-        ),
+    let source_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
         field: PayloadKey::Source.to_string(),
     };
 
-    let dest_program_allow_list = Rule::ProgramOwnedSet {
-        programs: HashSet::from_iter(
-            [
-                TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
-                random_programs.clone(),
-            ]
-            .concat(),
-        ),
+    let dest_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
         field: PayloadKey::Destination.to_string(),
     };
 
-    let authority_program_allow_list = Rule::ProgramOwnedSet {
-        programs: HashSet::from_iter(
-            [
-                TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
-                random_programs.clone(),
-            ]
-            .concat(),
-        ),
+    let authority_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            TRANSFER_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
         field: PayloadKey::Authority.to_string(),
     };
 
@@ -113,25 +107,21 @@ fn get_composed_rules() -> ComposedRules {
         field: PayloadKey::Destination.to_string(),
     };
 
-    let delegate_program_allow_list = Rule::ProgramOwnedSet {
-        programs: HashSet::from_iter(
-            [
-                DELEGATE_PROGRAM_BASE_ALLOW_LIST.to_vec(),
-                random_programs.clone(),
-            ]
-            .concat(),
-        ),
+    let delegate_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            DELEGATE_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs.clone(),
+        ]
+        .concat(),
         field: PayloadKey::Delegate.to_string(),
     };
 
-    let advanced_delegate_program_allow_list = Rule::ProgramOwnedSet {
-        programs: HashSet::from_iter(
-            [
-                ADVANCED_DELEGATE_PROGRAM_BASE_ALLOW_LIST.to_vec(),
-                random_programs,
-            ]
-            .concat(),
-        ),
+    let advanced_delegate_program_allow_list = Rule::ProgramOwnedList {
+        programs: [
+            ADVANCED_DELEGATE_PROGRAM_BASE_ALLOW_LIST.to_vec(),
+            random_programs,
+        ]
+        .concat(),
         field: PayloadKey::Delegate.to_string(),
     };
 
@@ -1027,7 +1017,7 @@ async fn prog_owner_not_on_list_fails() {
         solana_program_test::BanksClientError::TransactionError(
             TransactionError::InstructionError(_, InstructionError::Custom(error)),
         ) => {
-            assert_eq!(error, RuleSetError::ProgramOwnedSetCheckFailed as u32);
+            assert_eq!(error, RuleSetError::ProgramOwnedListCheckFailed as u32);
         }
         _ => panic!("Unexpected error: {:?}", err),
     }
@@ -1126,7 +1116,7 @@ async fn prog_owned_but_zero_data_length() {
         solana_program_test::BanksClientError::TransactionError(
             TransactionError::InstructionError(_, InstructionError::Custom(error)),
         ) => {
-            assert_eq!(error, RuleSetError::ProgramOwnedSetCheckFailed as u32);
+            assert_eq!(error, RuleSetError::ProgramOwnedListCheckFailed as u32);
         }
         _ => panic!("Unexpected error: {:?}", err),
     }

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -116,16 +116,22 @@ impl Display for DelegateScenario {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Operation {
     Transfer { scenario: TransferScenario },
+    TransferNamespace,
     Update { scenario: UpdateScenario },
+    UpdateNamespace,
     Delegate { scenario: DelegateScenario },
+    DelegateNamespace,
 }
 
 impl ToString for Operation {
     fn to_string(&self) -> String {
         match self {
             Self::Transfer { scenario } => format!("Transfer:{}", scenario),
+            Self::TransferNamespace => "Transfer".to_string(),
             Self::Update { scenario } => format!("Update:{}", scenario),
+            Self::UpdateNamespace => "Update".to_string(),
             Self::Delegate { scenario } => format!("Delegate:{}", scenario),
+            Self::DelegateNamespace => "Delegate".to_string(),
         }
     }
 }


### PR DESCRIPTION
Allowing for operation namespaces like delegate as fallback operations if the main operation delegate:transfer doesn't exist.