### PR TITLE
Fix TS examples

### DIFF
--- a/cli/examples/additional_signer.json
+++ b/cli/examples/additional_signer.json
@@ -1,6 +1,5 @@
 [
     1,
-    "AdditionalSignerRuleSet",
     [
         179,
         107,
@@ -35,6 +34,7 @@
         54,
         236
     ],
+    "AdditionalSignerRuleSet",
     {
         "Transfer": {
             "AdditionalSigner": [

--- a/cli/examples/all.json
+++ b/cli/examples/all.json
@@ -1,6 +1,5 @@
 [
     1,
-    "AllRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "AllRuleSet",
     {
       "Transfer": {
         "All": [

--- a/cli/examples/amount.json
+++ b/cli/examples/amount.json
@@ -1,6 +1,5 @@
 [
     1,
-    "AmountRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "AmountRuleSet",
     {
       "Transfer": {
         "Amount": [

--- a/cli/examples/any.json
+++ b/cli/examples/any.json
@@ -1,6 +1,5 @@
 [
     1,
-    "AnyRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "AnyRuleSet",
     {
       "Transfer": {
         "Any": [

--- a/cli/examples/derived_key_match.json
+++ b/cli/examples/derived_key_match.json
@@ -1,6 +1,5 @@
 [
     1,
-    "DerivedKeyMatchRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "DerivedKeyMatchRuleSet",
     {
       "Transfer": {
         "DerivedKeyMatch": [

--- a/cli/examples/not.json
+++ b/cli/examples/not.json
@@ -1,6 +1,5 @@
 [
     1,
-    "NotRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "NotRuleSet",
     {
       "Transfer": {
         "Not": [

--- a/cli/examples/pass.json
+++ b/cli/examples/pass.json
@@ -1,6 +1,5 @@
 [
     1,
-    "PassRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "PassRuleSet",
     {
       "Transfer": "Pass"
     }

--- a/cli/examples/program_owned.json
+++ b/cli/examples/program_owned.json
@@ -1,6 +1,5 @@
 [
     1,
-    "ProgramOwnedRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "ProgramOwnedRuleSet",
     {
       "Transfer": {
         "ProgramOwned": [

--- a/cli/examples/pubkey_list_match.json
+++ b/cli/examples/pubkey_list_match.json
@@ -1,6 +1,5 @@
 [
     1,
-    "PubkeyListMatchRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "PubkeyListMatchRuleSet",
     {
       "Transfer": {
         "PubkeyListMatch": [

--- a/cli/examples/pubkey_match.json
+++ b/cli/examples/pubkey_match.json
@@ -1,6 +1,5 @@
 [
     1,
-    "PubkeyMatchRuleSet",
     [
         179,
         107,
@@ -35,6 +34,7 @@
         54,
         236
     ],
+    "PubkeyMatchRuleSet",
     {
         "Transfer": {
             "PubkeyMatch": [

--- a/cli/examples/pubkey_tree_match.json
+++ b/cli/examples/pubkey_tree_match.json
@@ -1,6 +1,5 @@
 [
     1,
-    "PubkeyTreeMatchRuleSet",
     [
       179,
       107,
@@ -35,6 +34,7 @@
       54,
       236
     ],
+    "PubkeyTreeMatchRuleSet",
     {
       "Transfer": {
         "PubkeyTreeMatch": [

--- a/cli/src/auth.ts
+++ b/cli/src/auth.ts
@@ -35,8 +35,8 @@ program
         }
 
         const rulesetFile = JSON.parse(fs.readFileSync(ruleset, 'utf-8'));
-        rulesetFile[1] = name;
-        rulesetFile[2] = Array.from(payer.publicKey.toBytes());
+        rulesetFile[1] = Array.from(payer.publicKey.toBytes());
+        rulesetFile[2] = name;
 
         const encoded = encode(rulesetFile);
         let rulesetAddress = await createTokenAuthorizationRules(connection, payer, name, encoded);


### PR DESCRIPTION
Program currently throws an error on deserialization of the example JSON files, this PR makes them work again

- Updates example files to have the name field following the owner key field
- Updates indices of the ruleset that are updated before serialization in the CLI