### PR TITLE
Overwrite content on first chunk

### DIFF
--- a/packages/sdk/test/_setup.ts
+++ b/packages/sdk/test/_setup.ts
@@ -69,7 +69,7 @@ export const createOrUpdateLargeRuleset = async (
 
   for (let i = 0; i < chunks; i++) {
     const chunk = data.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
-    await writeAndPuff(connection, payer, name, chunk);
+    await writeAndPuff(connection, payer, name, chunk, i == 0);
   }
 
   const bufferAddress = await findRuleSetBufferPDA(payer.publicKey);


### PR DESCRIPTION
PR to use the `overwrite` argument to replace the contents of the buffer account when the first "chunk" is sent to the `write_to_buffer` instruction.